### PR TITLE
Version 3 - Add MPI pipeline for Spotify lyrics analysis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+CC=mpicc
+CFLAGS=-O2 -Wall -Wextra -std=c11 -Ithird_party
+LDFLAGS=
+TARGET=spotify_mpi
+SRC=src/spotify_mpi.c
+
+all: $(TARGET)
+
+$(TARGET): $(SRC)
+	$(CC) $(CFLAGS) -o $@ $(SRC) $(LDFLAGS)
+
+clean:
+	rm -f $(TARGET)
+
+.PHONY: all clean

--- a/README.md
+++ b/README.md
@@ -1,10 +1,96 @@
 # Music-Analyst-AI
 
-Desenvolver uma aplicação em paralelo utilizando o MPI com C para processar em paralelo os dados referentes a músicas no Spotify (https://www.kaggle.com/datasets/notshrirang/spotify-million-song-dataset), o trabalho consistirá em obter três tipos de informação do dataset, sendo elas:
+Aplicação paralela utilizando MPI em C para analisar o conjunto de dados [Spotify Million Song Dataset](https://www.kaggle.com/datasets/notshrirang/spotify-million-song-dataset). O projeto calcula contagem de palavras das letras, artistas com mais músicas e realiza classificação de sentimento (Positiva, Neutra, Negativa) integrando com um modelo local de linguagem ou com um classificador léxico de fallback.
 
-1 - Contagem de palavras: Contar a aparição de cada palavra presente nas letras, este desafio irá compor 40% da nota do código.
-2 - Artistas com mais músicas: Encontrar os artistas com a maior quantidade de músicas, este desafio irá compor 40% da nota do código.
-3 - Classificação: Fazer a classificação entre "Positiva", "Neutra" e "Negativa" sobre a letra das músicas usando uma integração com um modelo local de linguagem, após a classificação deve ser contado o total de cada classe, para este desafio pode ser utilizado uma linguagem auxiliar, como o python, para fazer a chamada do LLM, além de um software para auxiliar na execução do modelo, como por exemplo o Ollama (https://ollama.com). Este desafio irá compor 20% da nota do código.
+## Estrutura do projeto
 
-- Para a entrega anexar todos os arquivos necessários para executar a solução.
-- Calcular as métricas de desempenho da aplicação, analisando o que impactou o resultado.
+```
+├── Makefile
+├── sentiment_classifier.py
+├── spotify_millsongdata.csv
+├── src
+│   └── spotify_mpi.c
+└── third_party
+    └── uthash.h
+```
+
+- `src/spotify_mpi.c`: código C com MPI responsável pelo processamento paralelo das letras.
+- `sentiment_classifier.py`: script auxiliar em Python que integra com um modelo local (Ollama) ou executa uma classificação baseada em léxico caso o modelo não esteja disponível.
+- `third_party/uthash.h`: dependência externa usada para implementar tabelas hash em C.
+
+## Pré-requisitos
+
+- [MPI](https://www.mpi-forum.org/) com `mpicc` e `mpirun` instalados (por exemplo, via OpenMPI ou MPICH).
+- Python 3.8+ com a biblioteca padrão.
+- Opcional: [Ollama](https://ollama.com) ou outro servidor de modelo local acessível via comando `ollama run` para classificação neural. Caso não esteja disponível, o script em Python utilizará automaticamente o classificador léxico incluso.
+
+## Compilação
+
+```bash
+make
+```
+
+O comando gera o executável `spotify_mpi` na raiz do projeto.
+
+## Execução
+
+O programa espera o arquivo `spotify_millsongdata.csv` na raiz. Para executar com 4 processos MPI:
+
+```bash
+mpirun -np 4 ./spotify_mpi
+```
+
+Também é possível informar um caminho alternativo para o CSV:
+
+```bash
+mpirun -np 4 ./spotify_mpi /caminho/para/spotify_millsongdata.csv
+```
+
+### Saída
+
+O processo 0 imprime:
+
+1. Top 20 palavras mais frequentes nas letras.
+2. Top 20 artistas com maior quantidade de músicas.
+3. Contagem total de letras classificadas como Positivas, Neutras e Negativas.
+4. Métricas de desempenho: tempo médio e máximo de processamento dos dados e de classificação das letras.
+
+Durante a execução cada processo gera um arquivo temporário `classification_rank_<id>.txt` com as letras que processou. Esse arquivo é removido automaticamente após a classificação.
+
+## Classificador de sentimentos
+
+O script `sentiment_classifier.py` recebe como entrada um arquivo com uma letra por linha e retorna três contagens (positivas, neutras, negativas). O programa MPI chama esse script automaticamente para cada partição de dados.
+
+Uso isolado:
+
+```bash
+python3 sentiment_classifier.py --input classification_rank_0.txt --model llama3
+```
+
+Argumentos principais:
+
+- `--input`: arquivo com uma letra por linha (obrigatório).
+- `--model`: nome do modelo Ollama a ser utilizado. Se omitido ou se o comando `ollama run` falhar, o script aplica um classificador léxico local.
+- `--report`: caminho opcional para salvar um relatório JSON com as contagens.
+
+## Métricas de desempenho
+
+O código utiliza `MPI_Wtime` para medir tempos:
+
+- **Tempo de processamento**: leitura/distribuição das músicas, contagem de palavras e artistas.
+- **Tempo de classificação**: execução do script Python para a partição local.
+
+As métricas são agregadas usando `MPI_Reduce`, permitindo analisar gargalos (processos mais lentos) e impacto da classificação externa.
+
+## Limpeza
+
+```bash
+make clean
+```
+
+Remove o executável gerado.
+
+## Observações
+
+- O classificador léxico não depende de rede e serve como fallback em ambientes sem Ollama.
+- Para rodar com um modelo local real, instale o Ollama, baixe o modelo desejado (`ollama pull <modelo>`) e informe `--model` via variável de ambiente `OLLAMA_MODEL` ou ajustando o script conforme necessário.

--- a/sentiment_classifier.py
+++ b/sentiment_classifier.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Simple sentiment classifier integrating with a local LLM when available.
+
+The script expects an input file containing one lyric per line and outputs three
+integers separated by spaces representing the number of positive, neutral and
+negative lyrics respectively. The integration attempts to use a locally running
+Ollama model (if installed) and falls back to a rule-based classifier when the
+model is not available.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Iterable, List, Optional
+
+# Basic sentiment lexicon as a fallback when no LLM is available.
+POSITIVE_WORDS = {
+    "amor",
+    "feliz",
+    "alegria",
+    "bom",
+    "boa",
+    "fantástico",
+    "incrível",
+    "lindo",
+    "maravilhoso",
+    "sucesso",
+    "peace",
+    "love",
+    "happy",
+    "joy",
+    "smile",
+    "sunshine",
+}
+
+NEGATIVE_WORDS = {
+    "triste",
+    "odio",
+    "ódio",
+    "dor",
+    "choro",
+    "medo",
+    "raiva",
+    "solidão",
+    "broken",
+    "cry",
+    "sad",
+    "pain",
+    "hurt",
+    "dark",
+    "lonely",
+}
+
+WORD_RE = re.compile(r"[\w']+")
+
+
+@dataclass
+class SentimentCounts:
+    positive: int = 0
+    neutral: int = 0
+    negative: int = 0
+
+    def as_tuple(self) -> tuple[int, int, int]:
+        return self.positive, self.neutral, self.negative
+
+
+def call_ollama(prompt: str, model: str) -> Optional[str]:
+    """Call a local Ollama model if available."""
+    try:
+        completed = subprocess.run(
+            ["ollama", "run", model],
+            input=prompt,
+            check=True,
+            text=True,
+            capture_output=True,
+            timeout=60,
+        )
+    except FileNotFoundError:
+        return None
+    except subprocess.CalledProcessError:
+        return None
+    except subprocess.TimeoutExpired:
+        return None
+
+    response = completed.stdout.strip()
+    if not response:
+        return None
+    return response
+
+
+def classify_with_llm(lyric: str, model: str) -> Optional[str]:
+    prompt = (
+        "Classifique a seguinte letra de música como Positiva, Neutra ou Negativa.\n"
+        "Responda somente com uma das palavras: Positiva, Neutra ou Negativa.\n"
+        f"Letra:\n{lyric.strip()}"
+    )
+    return call_ollama(prompt, model)
+
+
+def classify_rule_based(lyric: str) -> str:
+    words = WORD_RE.findall(lyric.lower())
+    if not words:
+        return "Neutra"
+    pos_hits = sum(1 for token in words if token in POSITIVE_WORDS)
+    neg_hits = sum(1 for token in words if token in NEGATIVE_WORDS)
+    if pos_hits > neg_hits:
+        return "Positiva"
+    if neg_hits > pos_hits:
+        return "Negativa"
+    return "Neutra"
+
+
+def classify_lyric(lyric: str, model: Optional[str]) -> str:
+    if model:
+        response = classify_with_llm(lyric, model)
+        if response:
+            normalized = response.strip().split()[0].capitalize()
+            if normalized in {"Positiva", "Neutra", "Negativa"}:
+                return normalized
+    return classify_rule_based(lyric)
+
+
+def load_lyrics(path: str) -> Iterable[str]:
+    with open(path, "r", encoding="utf-8") as handle:
+        for line in handle:
+            yield line.strip()
+
+
+def aggregate_sentiments(lyrics: Iterable[str], model: Optional[str]) -> SentimentCounts:
+    counts = SentimentCounts()
+    for lyric in lyrics:
+        if not lyric:
+            counts.neutral += 1
+            continue
+        sentiment = classify_lyric(lyric, model)
+        if sentiment == "Positiva":
+            counts.positive += 1
+        elif sentiment == "Negativa":
+            counts.negative += 1
+        else:
+            counts.neutral += 1
+    return counts
+
+
+def parse_args(args: List[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Classificador de sentimentos para letras.")
+    parser.add_argument("--input", required=True, help="Arquivo com uma letra por linha.")
+    parser.add_argument(
+        "--model",
+        default=os.getenv("OLLAMA_MODEL"),
+        help=(
+            "Nome do modelo Ollama a ser utilizado. Se não informado ou em caso de erro, "
+            "será utilizado o classificador baseado em léxico."
+        ),
+    )
+    parser.add_argument(
+        "--report",
+        default=None,
+        help="Arquivo JSON opcional para salvar o relatório de contagens.",
+    )
+    return parser.parse_args(args)
+
+
+def save_report(report_path: str, counts: SentimentCounts) -> None:
+    payload = {
+        "positive": counts.positive,
+        "neutral": counts.neutral,
+        "negative": counts.negative,
+    }
+    with open(report_path, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False, indent=2)
+
+
+def main(argv: List[str]) -> int:
+    options = parse_args(argv)
+    if not os.path.exists(options.input):
+        print(f"Arquivo {options.input} não encontrado.", file=sys.stderr)
+        return 1
+
+    lyrics = load_lyrics(options.input)
+    counts = aggregate_sentiments(lyrics, options.model)
+
+    if options.report:
+        save_report(options.report, counts)
+
+    print(f"{counts.positive} {counts.neutral} {counts.negative}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/src/spotify_mpi.c
+++ b/src/spotify_mpi.c
@@ -1,0 +1,579 @@
+#include <mpi.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <errno.h>
+
+#include "uthash.h"
+
+#define TAG_LYRIC 100
+#define TAG_WORD 200
+#define TAG_ARTIST 300
+
+#define MAX_TOP_ITEMS 20
+
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
+typedef struct word_entry {
+    char *word;
+    long long count;
+    UT_hash_handle hh;
+} word_entry;
+
+typedef struct artist_entry {
+    char *artist;
+    long long count;
+    UT_hash_handle hh;
+} artist_entry;
+
+static void free_word_map(word_entry **map) {
+    word_entry *entry, *tmp;
+    HASH_ITER(hh, *map, entry, tmp) {
+        HASH_DEL(*map, entry);
+        free(entry->word);
+        free(entry);
+    }
+}
+
+static void free_artist_map(artist_entry **map) {
+    artist_entry *entry, *tmp;
+    HASH_ITER(hh, *map, entry, tmp) {
+        HASH_DEL(*map, entry);
+        free(entry->artist);
+        free(entry);
+    }
+}
+
+static void add_word(word_entry **map, const char *word, long long value) {
+    if (word[0] == '\0') {
+        return;
+    }
+    word_entry *entry = NULL;
+    HASH_FIND_STR(*map, word, entry);
+    if (entry == NULL) {
+        entry = (word_entry *)malloc(sizeof(word_entry));
+        if (!entry) {
+            fprintf(stderr, "Failed to allocate memory for word entry\n");
+            MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+        }
+        entry->word = strdup(word);
+        entry->count = value;
+        HASH_ADD_KEYPTR(hh, *map, entry->word, strlen(entry->word), entry);
+    } else {
+        entry->count += value;
+    }
+}
+
+static void add_artist(artist_entry **map, const char *artist, long long value) {
+    if (artist[0] == '\0') {
+        return;
+    }
+    artist_entry *entry = NULL;
+    HASH_FIND_STR(*map, artist, entry);
+    if (entry == NULL) {
+        entry = (artist_entry *)malloc(sizeof(artist_entry));
+        if (!entry) {
+            fprintf(stderr, "Failed to allocate memory for artist entry\n");
+            MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+        }
+        entry->artist = strdup(artist);
+        entry->count = value;
+        HASH_ADD_KEYPTR(hh, *map, entry->artist, strlen(entry->artist), entry);
+    } else {
+        entry->count += value;
+    }
+}
+
+static void sanitize_and_write_lyric(FILE *fp, const char *text) {
+    for (const char *ptr = text; *ptr; ++ptr) {
+        char c = *ptr;
+        if (c == '\r' || c == '\n') {
+            fputc(' ', fp);
+        } else {
+            fputc(c, fp);
+        }
+    }
+    fputc('\n', fp);
+}
+
+static void update_word_counts(word_entry **map, const char *text) {
+    char buffer[4096];
+    size_t buf_len = 0;
+    size_t text_len = strlen(text);
+
+    for (size_t i = 0; i <= text_len; ++i) {
+        char c = (i < text_len) ? text[i] : ' ';
+        if (isalnum((unsigned char)c)) {
+            if (buf_len + 1 >= sizeof(buffer)) {
+                buffer[buf_len] = '\0';
+                for (size_t j = 0; j < buf_len; ++j) {
+                    buffer[j] = (char)tolower((unsigned char)buffer[j]);
+                }
+                add_word(map, buffer, 1);
+                buf_len = 0;
+            }
+            buffer[buf_len++] = (char)tolower((unsigned char)c);
+        } else {
+            if (buf_len > 0) {
+                buffer[buf_len] = '\0';
+                add_word(map, buffer, 1);
+                buf_len = 0;
+            }
+        }
+    }
+}
+
+static int parse_csv_record(const char *record, char **artist, char **song, char **lyrics) {
+    const size_t len = strlen(record);
+    char *field_buffer = (char *)malloc(len + 1);
+    if (!field_buffer) {
+        return -1;
+    }
+    char *fields[4] = {NULL};
+    size_t field_index = 0;
+    size_t buf_len = 0;
+    int in_quotes = 0;
+
+    for (size_t i = 0; i < len; ++i) {
+        char c = record[i];
+        if (c == '\r') {
+            continue;
+        }
+        if (c == '"') {
+            if (in_quotes && i + 1 < len && record[i + 1] == '"') {
+                field_buffer[buf_len++] = '"';
+                ++i;
+            } else {
+                in_quotes = !in_quotes;
+            }
+        } else if (c == ',' && !in_quotes) {
+            field_buffer[buf_len] = '\0';
+            fields[field_index++] = strdup(field_buffer);
+            buf_len = 0;
+            if (field_index >= 4) {
+                break;
+            }
+        } else {
+            field_buffer[buf_len++] = c;
+        }
+    }
+
+    if (field_index < 4 && buf_len > 0) {
+        field_buffer[buf_len] = '\0';
+        fields[field_index++] = strdup(field_buffer);
+    }
+
+    free(field_buffer);
+
+    if (field_index != 4) {
+        for (size_t i = 0; i < field_index; ++i) {
+            free(fields[i]);
+        }
+        return -1;
+    }
+
+    *artist = fields[0];
+    *song = fields[1];
+    *lyrics = fields[3];
+    free(fields[2]);
+    return 0;
+}
+
+static int read_csv_record(FILE *fp, char **artist, char **song, char **lyrics) {
+    char *line = NULL;
+    size_t capacity = 0;
+    ssize_t read = 0;
+    size_t total_len = 0;
+    size_t quote_count = 0;
+    char *record_buffer = NULL;
+
+    while ((read = getline(&line, &capacity, fp)) != -1) {
+        record_buffer = (char *)realloc(record_buffer, total_len + read + 1);
+        if (!record_buffer) {
+            free(line);
+            return -1;
+        }
+        memcpy(record_buffer + total_len, line, (size_t)read);
+        total_len += (size_t)read;
+        record_buffer[total_len] = '\0';
+
+        for (ssize_t i = 0; i < read; ++i) {
+            if (line[i] == '"') {
+                ++quote_count;
+            }
+        }
+        if (quote_count % 2 == 0) {
+            break;
+        }
+    }
+
+    free(line);
+
+    if (total_len == 0) {
+        free(record_buffer);
+        return -1;
+    }
+
+    int result = parse_csv_record(record_buffer, artist, song, lyrics);
+    free(record_buffer);
+    return result;
+}
+
+static void process_record(word_entry **word_map, artist_entry **artist_map, FILE *tmp_fp,
+                           const char *artist, const char *lyrics) {
+    if (artist && artist[0]) {
+        add_artist(artist_map, artist, 1);
+    }
+    if (lyrics && lyrics[0]) {
+        update_word_counts(word_map, lyrics);
+        if (tmp_fp) {
+            sanitize_and_write_lyric(tmp_fp, lyrics);
+        }
+    }
+}
+
+static void send_termination_signal(int dest, int tag) {
+    int end = -1;
+    MPI_Send(&end, 1, MPI_INT, dest, tag, MPI_COMM_WORLD);
+}
+
+static void send_word_map_to_root(word_entry *map) {
+    word_entry *entry, *tmp;
+    HASH_ITER(hh, map, entry, tmp) {
+        int len = (int)strlen(entry->word);
+        MPI_Send(&len, 1, MPI_INT, 0, TAG_WORD, MPI_COMM_WORLD);
+        MPI_Send(entry->word, len, MPI_CHAR, 0, TAG_WORD, MPI_COMM_WORLD);
+        MPI_Send(&entry->count, 1, MPI_LONG_LONG, 0, TAG_WORD, MPI_COMM_WORLD);
+    }
+    send_termination_signal(0, TAG_WORD);
+}
+
+static void send_artist_map_to_root(artist_entry *map) {
+    artist_entry *entry, *tmp;
+    HASH_ITER(hh, map, entry, tmp) {
+        int len = (int)strlen(entry->artist);
+        MPI_Send(&len, 1, MPI_INT, 0, TAG_ARTIST, MPI_COMM_WORLD);
+        MPI_Send(entry->artist, len, MPI_CHAR, 0, TAG_ARTIST, MPI_COMM_WORLD);
+        MPI_Send(&entry->count, 1, MPI_LONG_LONG, 0, TAG_ARTIST, MPI_COMM_WORLD);
+    }
+    send_termination_signal(0, TAG_ARTIST);
+}
+
+static void merge_word_entry(word_entry **map, const char *word, long long count) {
+    add_word(map, word, count);
+}
+
+static void merge_artist_entry(artist_entry **map, const char *artist, long long count) {
+    add_artist(map, artist, count);
+}
+
+static int compare_word_entries(const void *a, const void *b) {
+    const word_entry *entry_a = *(const word_entry **)a;
+    const word_entry *entry_b = *(const word_entry **)b;
+    if (entry_a->count == entry_b->count) {
+        return strcmp(entry_a->word, entry_b->word);
+    }
+    return (entry_b->count > entry_a->count) - (entry_b->count < entry_a->count);
+}
+
+static int compare_artist_entries(const void *a, const void *b) {
+    const artist_entry *entry_a = *(const artist_entry **)a;
+    const artist_entry *entry_b = *(const artist_entry **)b;
+    if (entry_a->count == entry_b->count) {
+        return strcmp(entry_a->artist, entry_b->artist);
+    }
+    return (entry_b->count > entry_a->count) - (entry_b->count < entry_a->count);
+}
+
+static void print_top_words(word_entry *map) {
+    unsigned long count = HASH_COUNT(map);
+    word_entry **entries = (word_entry **)malloc(count * sizeof(word_entry *));
+    if (!entries) {
+        fprintf(stderr, "Failed to allocate memory for top words\n");
+        return;
+    }
+    word_entry *entry;
+    unsigned long idx = 0;
+    for (entry = map; entry != NULL; entry = entry->hh.next) {
+        entries[idx++] = entry;
+    }
+    qsort(entries, count, sizeof(word_entry *), compare_word_entries);
+    unsigned long limit = count < MAX_TOP_ITEMS ? count : MAX_TOP_ITEMS;
+    printf("\nTop %lu palavras:\n", limit);
+    for (unsigned long i = 0; i < limit; ++i) {
+        printf("%2lu. %-25s %lld\n", i + 1, entries[i]->word, entries[i]->count);
+    }
+    free(entries);
+}
+
+static void print_top_artists(artist_entry *map) {
+    unsigned long count = HASH_COUNT(map);
+    artist_entry **entries = (artist_entry **)malloc(count * sizeof(artist_entry *));
+    if (!entries) {
+        fprintf(stderr, "Failed to allocate memory for top artists\n");
+        return;
+    }
+    artist_entry *entry;
+    unsigned long idx = 0;
+    for (entry = map; entry != NULL; entry = entry->hh.next) {
+        entries[idx++] = entry;
+    }
+    qsort(entries, count, sizeof(artist_entry *), compare_artist_entries);
+    unsigned long limit = count < MAX_TOP_ITEMS ? count : MAX_TOP_ITEMS;
+    printf("\nTop %lu artistas por quantidade de músicas:\n", limit);
+    for (unsigned long i = 0; i < limit; ++i) {
+        printf("%2lu. %-30s %lld\n", i + 1, entries[i]->artist, entries[i]->count);
+    }
+    free(entries);
+}
+
+static int classify_chunk(const char *tmp_path, long long *positive, long long *neutral, long long *negative) {
+    char command[PATH_MAX];
+    snprintf(command, sizeof(command), "python3 sentiment_classifier.py --input \"%s\"", tmp_path);
+    FILE *pipe = popen(command, "r");
+    if (!pipe) {
+        fprintf(stderr, "Failed to execute sentiment classifier script.\n");
+        return -1;
+    }
+    char buffer[256];
+    if (!fgets(buffer, sizeof(buffer), pipe)) {
+        pclose(pipe);
+        fprintf(stderr, "No output from sentiment classifier script.\n");
+        return -1;
+    }
+    int status = pclose(pipe);
+    if (status == -1) {
+        fprintf(stderr, "Failed to close sentiment classifier pipe.\n");
+        return -1;
+    }
+
+    long long pos = 0, neu = 0, neg = 0;
+    if (sscanf(buffer, "%lld %lld %lld", &pos, &neu, &neg) != 3) {
+        fprintf(stderr, "Unexpected classifier output: %s\n", buffer);
+        return -1;
+    }
+
+    *positive = pos;
+    *neutral = neu;
+    *negative = neg;
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    MPI_Init(&argc, &argv);
+
+    int world_rank = 0;
+    int world_size = 0;
+    MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &world_size);
+
+    if (world_size < 1) {
+        fprintf(stderr, "At least one MPI process is required.\n");
+        MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+    }
+
+    const char *csv_path = "spotify_millsongdata.csv";
+    if (argc > 1) {
+        csv_path = argv[1];
+    }
+
+    word_entry *word_map = NULL;
+    artist_entry *artist_map = NULL;
+
+    char tmp_path[PATH_MAX];
+    snprintf(tmp_path, sizeof(tmp_path), "classification_rank_%d.txt", world_rank);
+    FILE *tmp_fp = fopen(tmp_path, "w");
+    if (!tmp_fp) {
+        fprintf(stderr, "Processo %d não conseguiu criar arquivo temporário %s: %s\n",
+                world_rank, tmp_path, strerror(errno));
+        MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+    }
+
+    double start_time = MPI_Wtime();
+
+    if (world_rank == 0) {
+        FILE *fp = fopen(csv_path, "r");
+        if (!fp) {
+            fprintf(stderr, "Não foi possível abrir %s: %s\n", csv_path, strerror(errno));
+            MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+        }
+
+        char *artist = NULL;
+        char *song = NULL;
+        char *lyrics = NULL;
+
+        char header[1024];
+        if (!fgets(header, sizeof(header), fp)) {
+            fprintf(stderr, "Arquivo CSV vazio ou inválido.\n");
+            fclose(fp);
+            MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+        }
+
+        long long record_index = 0;
+        while (read_csv_record(fp, &artist, &song, &lyrics) == 0) {
+            int dest = (int)(record_index % world_size);
+            if (dest == 0) {
+                process_record(&word_map, &artist_map, tmp_fp, artist, lyrics);
+            } else {
+                int artist_len = (int)strlen(artist);
+                int lyric_len = (int)strlen(lyrics);
+                MPI_Send(&lyric_len, 1, MPI_INT, dest, TAG_LYRIC, MPI_COMM_WORLD);
+                MPI_Send(&artist_len, 1, MPI_INT, dest, TAG_LYRIC, MPI_COMM_WORLD);
+                if (lyric_len > 0) {
+                    MPI_Send(lyrics, lyric_len, MPI_CHAR, dest, TAG_LYRIC, MPI_COMM_WORLD);
+                }
+                if (artist_len > 0) {
+                    MPI_Send(artist, artist_len, MPI_CHAR, dest, TAG_LYRIC, MPI_COMM_WORLD);
+                }
+            }
+            free(artist);
+            free(song);
+            free(lyrics);
+            artist = song = lyrics = NULL;
+            ++record_index;
+        }
+        fclose(fp);
+
+        for (int dest = 1; dest < world_size; ++dest) {
+            send_termination_signal(dest, TAG_LYRIC);
+        }
+    } else {
+        MPI_Status status;
+        while (1) {
+            int lyric_len = 0;
+            MPI_Recv(&lyric_len, 1, MPI_INT, 0, TAG_LYRIC, MPI_COMM_WORLD, &status);
+            if (lyric_len == -1) {
+                break;
+            }
+            int artist_len = 0;
+            MPI_Recv(&artist_len, 1, MPI_INT, 0, TAG_LYRIC, MPI_COMM_WORLD, &status);
+
+            char *lyric_buf = NULL;
+            char *artist_buf = NULL;
+            if (lyric_len > 0) {
+                lyric_buf = (char *)malloc((size_t)lyric_len + 1);
+                MPI_Recv(lyric_buf, lyric_len, MPI_CHAR, 0, TAG_LYRIC, MPI_COMM_WORLD, &status);
+                lyric_buf[lyric_len] = '\0';
+            } else {
+                lyric_buf = strdup("");
+            }
+            if (artist_len > 0) {
+                artist_buf = (char *)malloc((size_t)artist_len + 1);
+                MPI_Recv(artist_buf, artist_len, MPI_CHAR, 0, TAG_LYRIC, MPI_COMM_WORLD, &status);
+                artist_buf[artist_len] = '\0';
+            } else {
+                artist_buf = strdup("");
+            }
+
+            process_record(&word_map, &artist_map, tmp_fp, artist_buf, lyric_buf);
+
+            free(lyric_buf);
+            free(artist_buf);
+        }
+    }
+
+    fflush(tmp_fp);
+    fclose(tmp_fp);
+
+    double processing_end = MPI_Wtime();
+
+    long long local_positive = 0;
+    long long local_neutral = 0;
+    long long local_negative = 0;
+
+    double classification_start = MPI_Wtime();
+    if (classify_chunk(tmp_path, &local_positive, &local_neutral, &local_negative) != 0) {
+        fprintf(stderr, "Processo %d não conseguiu classificar o lote de letras.\n", world_rank);
+    }
+    double classification_end = MPI_Wtime();
+
+    remove(tmp_path);
+
+    long long global_positive = 0;
+    long long global_neutral = 0;
+    long long global_negative = 0;
+
+    MPI_Reduce(&local_positive, &global_positive, 1, MPI_LONG_LONG, MPI_SUM, 0, MPI_COMM_WORLD);
+    MPI_Reduce(&local_neutral, &global_neutral, 1, MPI_LONG_LONG, MPI_SUM, 0, MPI_COMM_WORLD);
+    MPI_Reduce(&local_negative, &global_negative, 1, MPI_LONG_LONG, MPI_SUM, 0, MPI_COMM_WORLD);
+
+    double processing_time = processing_end - start_time;
+    double classification_time = classification_end - classification_start;
+
+    double max_processing_time = 0.0;
+    double avg_processing_time = 0.0;
+    double max_classification_time = 0.0;
+    double avg_classification_time = 0.0;
+
+    MPI_Reduce(&processing_time, &max_processing_time, 1, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
+    MPI_Reduce(&processing_time, &avg_processing_time, 1, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
+    MPI_Reduce(&classification_time, &max_classification_time, 1, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
+    MPI_Reduce(&classification_time, &avg_classification_time, 1, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
+
+    if (world_rank == 0) {
+        avg_processing_time /= world_size;
+        avg_classification_time /= world_size;
+
+        for (int source = 1; source < world_size; ++source) {
+            MPI_Status status;
+            while (1) {
+                int len = 0;
+                MPI_Recv(&len, 1, MPI_INT, source, TAG_WORD, MPI_COMM_WORLD, &status);
+                if (len == -1) {
+                    break;
+                }
+                char *word = (char *)malloc((size_t)len + 1);
+                MPI_Recv(word, len, MPI_CHAR, source, TAG_WORD, MPI_COMM_WORLD, &status);
+                word[len] = '\0';
+                long long count = 0;
+                MPI_Recv(&count, 1, MPI_LONG_LONG, source, TAG_WORD, MPI_COMM_WORLD, &status);
+                merge_word_entry(&word_map, word, count);
+                free(word);
+            }
+        }
+
+        for (int source = 1; source < world_size; ++source) {
+            MPI_Status status;
+            while (1) {
+                int len = 0;
+                MPI_Recv(&len, 1, MPI_INT, source, TAG_ARTIST, MPI_COMM_WORLD, &status);
+                if (len == -1) {
+                    break;
+                }
+                char *artist = (char *)malloc((size_t)len + 1);
+                MPI_Recv(artist, len, MPI_CHAR, source, TAG_ARTIST, MPI_COMM_WORLD, &status);
+                artist[len] = '\0';
+                long long count = 0;
+                MPI_Recv(&count, 1, MPI_LONG_LONG, source, TAG_ARTIST, MPI_COMM_WORLD, &status);
+                merge_artist_entry(&artist_map, artist, count);
+                free(artist);
+            }
+        }
+
+        print_top_words(word_map);
+        print_top_artists(artist_map);
+
+        printf("\nClassificação de sentimentos (total):\n");
+        printf("  Positivas: %lld\n", global_positive);
+        printf("  Neutras:   %lld\n", global_neutral);
+        printf("  Negativas: %lld\n", global_negative);
+
+        printf("\nMétricas de desempenho:\n");
+        printf("  Tempo médio de processamento (palavras/artistas): %.4f s\n", avg_processing_time);
+        printf("  Tempo máximo de processamento: %.4f s\n", max_processing_time);
+        printf("  Tempo médio de classificação: %.4f s\n", avg_classification_time);
+        printf("  Tempo máximo de classificação: %.4f s\n", max_classification_time);
+    } else {
+        send_word_map_to_root(word_map);
+        send_artist_map_to_root(artist_map);
+    }
+
+    free_word_map(&word_map);
+    free_artist_map(&artist_map);
+
+    MPI_Finalize();
+    return 0;
+}

--- a/third_party/uthash.h
+++ b/third_party/uthash.h
@@ -1,0 +1,1137 @@
+/*
+Copyright (c) 2003-2025, Troy D. Hanson  https://troydhanson.github.io/uthash/
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef UTHASH_H
+#define UTHASH_H
+
+#define UTHASH_VERSION 2.3.0
+
+#include <string.h>   /* memcmp, memset, strlen */
+#include <stddef.h>   /* ptrdiff_t */
+#include <stdlib.h>   /* exit */
+
+#if defined(HASH_NO_STDINT) && HASH_NO_STDINT
+/* The user doesn't have <stdint.h>, and must figure out their own way
+   to provide definitions for uint8_t and uint32_t. */
+#else
+#include <stdint.h>   /* uint8_t, uint32_t */
+#endif
+
+/* These macros use decltype or the earlier __typeof GNU extension.
+   As decltype is only available in newer compilers (VS2010 or gcc 4.3+
+   when compiling c++ source) this code uses whatever method is needed
+   or, for VS2008 where neither is available, uses casting workarounds. */
+#if !defined(DECLTYPE) && !defined(NO_DECLTYPE)
+#if defined(_MSC_VER)   /* MS compiler */
+#if _MSC_VER >= 1600 && defined(__cplusplus)  /* VS2010 or newer in C++ mode */
+#define DECLTYPE(x) (decltype(x))
+#else                   /* VS2008 or older (or VS2010 in C mode) */
+#define NO_DECLTYPE
+#endif
+#elif defined(__MCST__)  /* Elbrus C Compiler */
+#define DECLTYPE(x) (__typeof(x))
+#elif defined(__BORLANDC__) || defined(__ICCARM__) || defined(__LCC__) || defined(__WATCOMC__)
+#define NO_DECLTYPE
+#else                   /* GNU, Sun and other compilers */
+#define DECLTYPE(x) (__typeof(x))
+#endif
+#endif
+
+#ifdef NO_DECLTYPE
+#define DECLTYPE(x)
+#define DECLTYPE_ASSIGN(dst,src)                                                 \
+do {                                                                             \
+  char **_da_dst = (char**)(&(dst));                                             \
+  *_da_dst = (char*)(src);                                                       \
+} while (0)
+#else
+#define DECLTYPE_ASSIGN(dst,src)                                                 \
+do {                                                                             \
+  (dst) = DECLTYPE(dst)(src);                                                    \
+} while (0)
+#endif
+
+#ifndef uthash_malloc
+#define uthash_malloc(sz) malloc(sz)      /* malloc fcn                      */
+#endif
+#ifndef uthash_free
+#define uthash_free(ptr,sz) free(ptr)     /* free fcn                        */
+#endif
+#ifndef uthash_bzero
+#define uthash_bzero(a,n) memset(a,'\0',n)
+#endif
+#ifndef uthash_strlen
+#define uthash_strlen(s) strlen(s)
+#endif
+
+#ifndef HASH_FUNCTION
+#define HASH_FUNCTION(keyptr,keylen,hashv) HASH_JEN(keyptr, keylen, hashv)
+#endif
+
+#ifndef HASH_KEYCMP
+#define HASH_KEYCMP(a,b,n) memcmp(a,b,n)
+#endif
+
+#ifndef uthash_noexpand_fyi
+#define uthash_noexpand_fyi(tbl)          /* can be defined to log noexpand  */
+#endif
+#ifndef uthash_expand_fyi
+#define uthash_expand_fyi(tbl)            /* can be defined to log expands   */
+#endif
+
+#ifndef HASH_NONFATAL_OOM
+#define HASH_NONFATAL_OOM 0
+#endif
+
+#if HASH_NONFATAL_OOM
+/* malloc failures can be recovered from */
+
+#ifndef uthash_nonfatal_oom
+#define uthash_nonfatal_oom(obj) do {} while (0)    /* non-fatal OOM error */
+#endif
+
+#define HASH_RECORD_OOM(oomed) do { (oomed) = 1; } while (0)
+#define IF_HASH_NONFATAL_OOM(x) x
+
+#else
+/* malloc failures result in lost memory, hash tables are unusable */
+
+#ifndef uthash_fatal
+#define uthash_fatal(msg) exit(-1)        /* fatal OOM error */
+#endif
+
+#define HASH_RECORD_OOM(oomed) uthash_fatal("out of memory")
+#define IF_HASH_NONFATAL_OOM(x)
+
+#endif
+
+/* initial number of buckets */
+#define HASH_INITIAL_NUM_BUCKETS 32U     /* initial number of buckets        */
+#define HASH_INITIAL_NUM_BUCKETS_LOG2 5U /* lg2 of initial number of buckets */
+#define HASH_BKT_CAPACITY_THRESH 10U     /* expand when bucket count reaches */
+
+/* calculate the element whose hash handle address is hhp */
+#define ELMT_FROM_HH(tbl,hhp) ((void*)(((char*)(hhp)) - ((tbl)->hho)))
+/* calculate the hash handle from element address elp */
+#define HH_FROM_ELMT(tbl,elp) ((UT_hash_handle*)(void*)(((char*)(elp)) + ((tbl)->hho)))
+
+#define HASH_ROLLBACK_BKT(hh, head, itemptrhh)                                   \
+do {                                                                             \
+  struct UT_hash_handle *_hd_hh_item = (itemptrhh);                              \
+  unsigned _hd_bkt;                                                              \
+  HASH_TO_BKT(_hd_hh_item->hashv, (head)->hh.tbl->num_buckets, _hd_bkt);         \
+  (head)->hh.tbl->buckets[_hd_bkt].count++;                                      \
+  _hd_hh_item->hh_next = NULL;                                                   \
+  _hd_hh_item->hh_prev = NULL;                                                   \
+} while (0)
+
+#define HASH_VALUE(keyptr,keylen,hashv)                                          \
+do {                                                                             \
+  HASH_FUNCTION(keyptr, keylen, hashv);                                          \
+} while (0)
+
+#define HASH_FIND_BYHASHVALUE(hh,head,keyptr,keylen,hashval,out)                 \
+do {                                                                             \
+  (out) = NULL;                                                                  \
+  if (head) {                                                                    \
+    unsigned _hf_bkt;                                                            \
+    HASH_TO_BKT(hashval, (head)->hh.tbl->num_buckets, _hf_bkt);                  \
+    if (HASH_BLOOM_TEST((head)->hh.tbl, hashval)) {                              \
+      HASH_FIND_IN_BKT((head)->hh.tbl, hh, (head)->hh.tbl->buckets[ _hf_bkt ], keyptr, keylen, hashval, out); \
+    }                                                                            \
+  }                                                                              \
+} while (0)
+
+#define HASH_FIND(hh,head,keyptr,keylen,out)                                     \
+do {                                                                             \
+  (out) = NULL;                                                                  \
+  if (head) {                                                                    \
+    unsigned _hf_hashv;                                                          \
+    HASH_VALUE(keyptr, keylen, _hf_hashv);                                       \
+    HASH_FIND_BYHASHVALUE(hh, head, keyptr, keylen, _hf_hashv, out);             \
+  }                                                                              \
+} while (0)
+
+#ifdef HASH_BLOOM
+#define HASH_BLOOM_BITLEN (1UL << HASH_BLOOM)
+#define HASH_BLOOM_BYTELEN (HASH_BLOOM_BITLEN/8UL) + (((HASH_BLOOM_BITLEN%8UL)!=0UL) ? 1UL : 0UL)
+#define HASH_BLOOM_MAKE(tbl,oomed)                                               \
+do {                                                                             \
+  (tbl)->bloom_nbits = HASH_BLOOM;                                               \
+  (tbl)->bloom_bv = (uint8_t*)uthash_malloc(HASH_BLOOM_BYTELEN);                 \
+  if (!(tbl)->bloom_bv) {                                                        \
+    HASH_RECORD_OOM(oomed);                                                      \
+  } else {                                                                       \
+    uthash_bzero((tbl)->bloom_bv, HASH_BLOOM_BYTELEN);                           \
+    (tbl)->bloom_sig = HASH_BLOOM_SIGNATURE;                                     \
+  }                                                                              \
+} while (0)
+
+#define HASH_BLOOM_FREE(tbl)                                                     \
+do {                                                                             \
+  uthash_free((tbl)->bloom_bv, HASH_BLOOM_BYTELEN);                              \
+} while (0)
+
+#define HASH_BLOOM_BITSET(bv,idx) (bv[(idx)/8U] |= (1U << ((idx)%8U)))
+#define HASH_BLOOM_BITTEST(bv,idx) ((bv[(idx)/8U] & (1U << ((idx)%8U))) != 0)
+
+#define HASH_BLOOM_ADD(tbl,hashv)                                                \
+  HASH_BLOOM_BITSET((tbl)->bloom_bv, ((hashv) & (uint32_t)((1UL << (tbl)->bloom_nbits) - 1U)))
+
+#define HASH_BLOOM_TEST(tbl,hashv)                                               \
+  HASH_BLOOM_BITTEST((tbl)->bloom_bv, ((hashv) & (uint32_t)((1UL << (tbl)->bloom_nbits) - 1U)))
+
+#else
+#define HASH_BLOOM_MAKE(tbl,oomed)
+#define HASH_BLOOM_FREE(tbl)
+#define HASH_BLOOM_ADD(tbl,hashv)
+#define HASH_BLOOM_TEST(tbl,hashv) 1
+#define HASH_BLOOM_BYTELEN 0U
+#endif
+
+#define HASH_MAKE_TABLE(hh,head,oomed)                                           \
+do {                                                                             \
+  (head)->hh.tbl = (UT_hash_table*)uthash_malloc(sizeof(UT_hash_table));         \
+  if (!(head)->hh.tbl) {                                                         \
+    HASH_RECORD_OOM(oomed);                                                      \
+  } else {                                                                       \
+    uthash_bzero((head)->hh.tbl, sizeof(UT_hash_table));                         \
+    (head)->hh.tbl->tail = &((head)->hh);                                        \
+    (head)->hh.tbl->num_buckets = HASH_INITIAL_NUM_BUCKETS;                      \
+    (head)->hh.tbl->log2_num_buckets = HASH_INITIAL_NUM_BUCKETS_LOG2;            \
+    (head)->hh.tbl->hho = (char*)(&(head)->hh) - (char*)(head);                  \
+    (head)->hh.tbl->buckets = (UT_hash_bucket*)uthash_malloc(                    \
+        HASH_INITIAL_NUM_BUCKETS * sizeof(struct UT_hash_bucket));               \
+    (head)->hh.tbl->signature = HASH_SIGNATURE;                                  \
+    if (!(head)->hh.tbl->buckets) {                                              \
+      HASH_RECORD_OOM(oomed);                                                    \
+      uthash_free((head)->hh.tbl, sizeof(UT_hash_table));                        \
+    } else {                                                                     \
+      uthash_bzero((head)->hh.tbl->buckets,                                      \
+          HASH_INITIAL_NUM_BUCKETS * sizeof(struct UT_hash_bucket));             \
+      HASH_BLOOM_MAKE((head)->hh.tbl, oomed);                                    \
+      IF_HASH_NONFATAL_OOM(                                                      \
+        if (oomed) {                                                             \
+          uthash_free((head)->hh.tbl->buckets,                                   \
+              HASH_INITIAL_NUM_BUCKETS*sizeof(struct UT_hash_bucket));           \
+          uthash_free((head)->hh.tbl, sizeof(UT_hash_table));                    \
+        }                                                                        \
+      )                                                                          \
+    }                                                                            \
+  }                                                                              \
+} while (0)
+
+#define HASH_REPLACE_BYHASHVALUE_INORDER(hh,head,fieldname,keylen_in,hashval,add,replaced,cmpfcn) \
+do {                                                                             \
+  (replaced) = NULL;                                                             \
+  HASH_FIND_BYHASHVALUE(hh, head, &((add)->fieldname), keylen_in, hashval, replaced); \
+  if (replaced) {                                                                \
+    HASH_DELETE(hh, head, replaced);                                             \
+  }                                                                              \
+  HASH_ADD_KEYPTR_BYHASHVALUE_INORDER(hh, head, &((add)->fieldname), keylen_in, hashval, add, cmpfcn); \
+} while (0)
+
+#define HASH_REPLACE_BYHASHVALUE(hh,head,fieldname,keylen_in,hashval,add,replaced) \
+do {                                                                             \
+  (replaced) = NULL;                                                             \
+  HASH_FIND_BYHASHVALUE(hh, head, &((add)->fieldname), keylen_in, hashval, replaced); \
+  if (replaced) {                                                                \
+    HASH_DELETE(hh, head, replaced);                                             \
+  }                                                                              \
+  HASH_ADD_KEYPTR_BYHASHVALUE(hh, head, &((add)->fieldname), keylen_in, hashval, add); \
+} while (0)
+
+#define HASH_REPLACE(hh,head,fieldname,keylen_in,add,replaced)                   \
+do {                                                                             \
+  unsigned _hr_hashv;                                                            \
+  HASH_VALUE(&((add)->fieldname), keylen_in, _hr_hashv);                         \
+  HASH_REPLACE_BYHASHVALUE(hh, head, fieldname, keylen_in, _hr_hashv, add, replaced); \
+} while (0)
+
+#define HASH_REPLACE_INORDER(hh,head,fieldname,keylen_in,add,replaced,cmpfcn)    \
+do {                                                                             \
+  unsigned _hr_hashv;                                                            \
+  HASH_VALUE(&((add)->fieldname), keylen_in, _hr_hashv);                         \
+  HASH_REPLACE_BYHASHVALUE_INORDER(hh, head, fieldname, keylen_in, _hr_hashv, add, replaced, cmpfcn); \
+} while (0)
+
+#define HASH_APPEND_LIST(hh, head, add)                                          \
+do {                                                                             \
+  (add)->hh.next = NULL;                                                         \
+  (add)->hh.prev = ELMT_FROM_HH((head)->hh.tbl, (head)->hh.tbl->tail);           \
+  (head)->hh.tbl->tail->next = (add);                                            \
+  (head)->hh.tbl->tail = &((add)->hh);                                           \
+} while (0)
+
+#define HASH_AKBI_INNER_LOOP(hh,head,add,cmpfcn)                                 \
+do {                                                                             \
+  do {                                                                           \
+    if (cmpfcn(DECLTYPE(head)(_hs_iter), add) > 0) {                             \
+      break;                                                                     \
+    }                                                                            \
+  } while ((_hs_iter = HH_FROM_ELMT((head)->hh.tbl, _hs_iter)->next));           \
+} while (0)
+
+#ifdef NO_DECLTYPE
+#undef HASH_AKBI_INNER_LOOP
+#define HASH_AKBI_INNER_LOOP(hh,head,add,cmpfcn)                                 \
+do {                                                                             \
+  char *_hs_saved_head = (char*)(head);                                          \
+  do {                                                                           \
+    DECLTYPE_ASSIGN(head, _hs_iter);                                             \
+    if (cmpfcn(head, add) > 0) {                                                 \
+      DECLTYPE_ASSIGN(head, _hs_saved_head);                                     \
+      break;                                                                     \
+    }                                                                            \
+    DECLTYPE_ASSIGN(head, _hs_saved_head);                                       \
+  } while ((_hs_iter = HH_FROM_ELMT((head)->hh.tbl, _hs_iter)->next));           \
+} while (0)
+#endif
+
+#if HASH_NONFATAL_OOM
+
+#define HASH_ADD_TO_TABLE(hh,head,keyptr,keylen_in,hashval,add,oomed)            \
+do {                                                                             \
+  if (!(oomed)) {                                                                \
+    unsigned _ha_bkt;                                                            \
+    (head)->hh.tbl->num_items++;                                                 \
+    HASH_TO_BKT(hashval, (head)->hh.tbl->num_buckets, _ha_bkt);                  \
+    HASH_ADD_TO_BKT((head)->hh.tbl->buckets[_ha_bkt], hh, &(add)->hh, oomed);    \
+    if (oomed) {                                                                 \
+      HASH_ROLLBACK_BKT(hh, head, &(add)->hh);                                   \
+      HASH_DELETE_HH(hh, head, &(add)->hh);                                      \
+      (add)->hh.tbl = NULL;                                                      \
+      uthash_nonfatal_oom(add);                                                  \
+    } else {                                                                     \
+      HASH_BLOOM_ADD((head)->hh.tbl, hashval);                                   \
+      HASH_EMIT_KEY(hh, head, keyptr, keylen_in);                                \
+    }                                                                            \
+  } else {                                                                       \
+    (add)->hh.tbl = NULL;                                                        \
+    uthash_nonfatal_oom(add);                                                    \
+  }                                                                              \
+} while (0)
+
+#else
+
+#define HASH_ADD_TO_TABLE(hh,head,keyptr,keylen_in,hashval,add,oomed)            \
+do {                                                                             \
+  unsigned _ha_bkt;                                                              \
+  (head)->hh.tbl->num_items++;                                                   \
+  HASH_TO_BKT(hashval, (head)->hh.tbl->num_buckets, _ha_bkt);                    \
+  HASH_ADD_TO_BKT((head)->hh.tbl->buckets[_ha_bkt], hh, &(add)->hh, oomed);      \
+  HASH_BLOOM_ADD((head)->hh.tbl, hashval);                                       \
+  HASH_EMIT_KEY(hh, head, keyptr, keylen_in);                                    \
+} while (0)
+
+#endif
+
+
+#define HASH_ADD_KEYPTR_BYHASHVALUE_INORDER(hh,head,keyptr,keylen_in,hashval,add,cmpfcn) \
+do {                                                                             \
+  IF_HASH_NONFATAL_OOM( int _ha_oomed = 0; )                                     \
+  (add)->hh.hashv = (hashval);                                                   \
+  (add)->hh.key = (char*) (keyptr);                                              \
+  (add)->hh.keylen = (unsigned) (keylen_in);                                     \
+  if (!(head)) {                                                                 \
+    (add)->hh.next = NULL;                                                       \
+    (add)->hh.prev = NULL;                                                       \
+    HASH_MAKE_TABLE(hh, add, _ha_oomed);                                         \
+    IF_HASH_NONFATAL_OOM( if (!_ha_oomed) { )                                    \
+      (head) = (add);                                                            \
+    IF_HASH_NONFATAL_OOM( } )                                                    \
+  } else {                                                                       \
+    void *_hs_iter = (head);                                                     \
+    (add)->hh.tbl = (head)->hh.tbl;                                              \
+    HASH_AKBI_INNER_LOOP(hh, head, add, cmpfcn);                                 \
+    if (_hs_iter) {                                                              \
+      (add)->hh.next = _hs_iter;                                                 \
+      if (((add)->hh.prev = HH_FROM_ELMT((head)->hh.tbl, _hs_iter)->prev)) {     \
+        HH_FROM_ELMT((head)->hh.tbl, (add)->hh.prev)->next = (add);              \
+      } else {                                                                   \
+        (head) = (add);                                                          \
+      }                                                                          \
+      HH_FROM_ELMT((head)->hh.tbl, _hs_iter)->prev = (add);                      \
+    } else {                                                                     \
+      HASH_APPEND_LIST(hh, head, add);                                           \
+    }                                                                            \
+  }                                                                              \
+  HASH_ADD_TO_TABLE(hh, head, keyptr, keylen_in, hashval, add, _ha_oomed);       \
+  HASH_FSCK(hh, head, "HASH_ADD_KEYPTR_BYHASHVALUE_INORDER");                    \
+} while (0)
+
+#define HASH_ADD_KEYPTR_INORDER(hh,head,keyptr,keylen_in,add,cmpfcn)             \
+do {                                                                             \
+  unsigned _hs_hashv;                                                            \
+  HASH_VALUE(keyptr, keylen_in, _hs_hashv);                                      \
+  HASH_ADD_KEYPTR_BYHASHVALUE_INORDER(hh, head, keyptr, keylen_in, _hs_hashv, add, cmpfcn); \
+} while (0)
+
+#define HASH_ADD_BYHASHVALUE_INORDER(hh,head,fieldname,keylen_in,hashval,add,cmpfcn) \
+  HASH_ADD_KEYPTR_BYHASHVALUE_INORDER(hh, head, &((add)->fieldname), keylen_in, hashval, add, cmpfcn)
+
+#define HASH_ADD_INORDER(hh,head,fieldname,keylen_in,add,cmpfcn)                 \
+  HASH_ADD_KEYPTR_INORDER(hh, head, &((add)->fieldname), keylen_in, add, cmpfcn)
+
+#define HASH_ADD_KEYPTR_BYHASHVALUE(hh,head,keyptr,keylen_in,hashval,add)        \
+do {                                                                             \
+  IF_HASH_NONFATAL_OOM( int _ha_oomed = 0; )                                     \
+  (add)->hh.hashv = (hashval);                                                   \
+  (add)->hh.key = (const void*) (keyptr);                                        \
+  (add)->hh.keylen = (unsigned) (keylen_in);                                     \
+  if (!(head)) {                                                                 \
+    (add)->hh.next = NULL;                                                       \
+    (add)->hh.prev = NULL;                                                       \
+    HASH_MAKE_TABLE(hh, add, _ha_oomed);                                         \
+    IF_HASH_NONFATAL_OOM( if (!_ha_oomed) { )                                    \
+      (head) = (add);                                                            \
+    IF_HASH_NONFATAL_OOM( } )                                                    \
+  } else {                                                                       \
+    (add)->hh.tbl = (head)->hh.tbl;                                              \
+    HASH_APPEND_LIST(hh, head, add);                                             \
+  }                                                                              \
+  HASH_ADD_TO_TABLE(hh, head, keyptr, keylen_in, hashval, add, _ha_oomed);       \
+  HASH_FSCK(hh, head, "HASH_ADD_KEYPTR_BYHASHVALUE");                            \
+} while (0)
+
+#define HASH_ADD_KEYPTR(hh,head,keyptr,keylen_in,add)                            \
+do {                                                                             \
+  unsigned _ha_hashv;                                                            \
+  HASH_VALUE(keyptr, keylen_in, _ha_hashv);                                      \
+  HASH_ADD_KEYPTR_BYHASHVALUE(hh, head, keyptr, keylen_in, _ha_hashv, add);      \
+} while (0)
+
+#define HASH_ADD_BYHASHVALUE(hh,head,fieldname,keylen_in,hashval,add)            \
+  HASH_ADD_KEYPTR_BYHASHVALUE(hh, head, &((add)->fieldname), keylen_in, hashval, add)
+
+#define HASH_ADD(hh,head,fieldname,keylen_in,add)                                \
+  HASH_ADD_KEYPTR(hh, head, &((add)->fieldname), keylen_in, add)
+
+#define HASH_TO_BKT(hashv,num_bkts,bkt)                                          \
+do {                                                                             \
+  bkt = ((hashv) & ((num_bkts) - 1U));                                           \
+} while (0)
+
+/* delete "delptr" from the hash table.
+ * "the usual" patch-up process for the app-order doubly-linked-list.
+ * The use of _hd_hh_del below deserves special explanation.
+ * These used to be expressed using (delptr) but that led to a bug
+ * if someone used the same symbol for the head and deletee, like
+ *  HASH_DELETE(hh,users,users);
+ * We want that to work, but by changing the head (users) below
+ * we were forfeiting our ability to further refer to the deletee (users)
+ * in the patch-up process. Solution: use scratch space to
+ * copy the deletee pointer, then the latter references are via that
+ * scratch pointer rather than through the repointed (users) symbol.
+ */
+#define HASH_DELETE(hh,head,delptr)                                              \
+    HASH_DELETE_HH(hh, head, &(delptr)->hh)
+
+#define HASH_DELETE_HH(hh,head,delptrhh)                                         \
+do {                                                                             \
+  const struct UT_hash_handle *_hd_hh_del = (delptrhh);                          \
+  if ((_hd_hh_del->prev == NULL) && (_hd_hh_del->next == NULL)) {                \
+    HASH_BLOOM_FREE((head)->hh.tbl);                                             \
+    uthash_free((head)->hh.tbl->buckets,                                         \
+                (head)->hh.tbl->num_buckets * sizeof(struct UT_hash_bucket));    \
+    uthash_free((head)->hh.tbl, sizeof(UT_hash_table));                          \
+    (head) = NULL;                                                               \
+  } else {                                                                       \
+    unsigned _hd_bkt;                                                            \
+    if (_hd_hh_del == (head)->hh.tbl->tail) {                                    \
+      (head)->hh.tbl->tail = HH_FROM_ELMT((head)->hh.tbl, _hd_hh_del->prev);     \
+    }                                                                            \
+    if (_hd_hh_del->prev != NULL) {                                              \
+      HH_FROM_ELMT((head)->hh.tbl, _hd_hh_del->prev)->next = _hd_hh_del->next;   \
+    } else {                                                                     \
+      DECLTYPE_ASSIGN(head, _hd_hh_del->next);                                   \
+    }                                                                            \
+    if (_hd_hh_del->next != NULL) {                                              \
+      HH_FROM_ELMT((head)->hh.tbl, _hd_hh_del->next)->prev = _hd_hh_del->prev;   \
+    }                                                                            \
+    HASH_TO_BKT(_hd_hh_del->hashv, (head)->hh.tbl->num_buckets, _hd_bkt);        \
+    HASH_DEL_IN_BKT((head)->hh.tbl->buckets[_hd_bkt], _hd_hh_del);               \
+    (head)->hh.tbl->num_items--;                                                 \
+  }                                                                              \
+  HASH_FSCK(hh, head, "HASH_DELETE_HH");                                         \
+} while (0)
+
+/* convenience forms of HASH_FIND/HASH_ADD/HASH_DEL */
+#define HASH_FIND_STR(head,findstr,out)                                          \
+do {                                                                             \
+    unsigned _uthash_hfstr_keylen = (unsigned)uthash_strlen(findstr);            \
+    HASH_FIND(hh, head, findstr, _uthash_hfstr_keylen, out);                     \
+} while (0)
+#define HASH_ADD_STR(head,strfield,add)                                          \
+do {                                                                             \
+    unsigned _uthash_hastr_keylen = (unsigned)uthash_strlen((add)->strfield);    \
+    HASH_ADD(hh, head, strfield[0], _uthash_hastr_keylen, add);                  \
+} while (0)
+#define HASH_REPLACE_STR(head,strfield,add,replaced)                             \
+do {                                                                             \
+    unsigned _uthash_hrstr_keylen = (unsigned)uthash_strlen((add)->strfield);    \
+    HASH_REPLACE(hh, head, strfield[0], _uthash_hrstr_keylen, add, replaced);    \
+} while (0)
+#define HASH_FIND_INT(head,findint,out)                                          \
+    HASH_FIND(hh,head,findint,sizeof(int),out)
+#define HASH_ADD_INT(head,intfield,add)                                          \
+    HASH_ADD(hh,head,intfield,sizeof(int),add)
+#define HASH_REPLACE_INT(head,intfield,add,replaced)                             \
+    HASH_REPLACE(hh,head,intfield,sizeof(int),add,replaced)
+#define HASH_FIND_PTR(head,findptr,out)                                          \
+    HASH_FIND(hh,head,findptr,sizeof(void *),out)
+#define HASH_ADD_PTR(head,ptrfield,add)                                          \
+    HASH_ADD(hh,head,ptrfield,sizeof(void *),add)
+#define HASH_REPLACE_PTR(head,ptrfield,add,replaced)                             \
+    HASH_REPLACE(hh,head,ptrfield,sizeof(void *),add,replaced)
+#define HASH_DEL(head,delptr)                                                    \
+    HASH_DELETE(hh,head,delptr)
+
+/* HASH_FSCK checks hash integrity on every add/delete when HASH_DEBUG is defined.
+ * This is for uthash developer only; it compiles away if HASH_DEBUG isn't defined.
+ */
+#ifdef HASH_DEBUG
+#include <stdio.h>   /* fprintf, stderr */
+#define HASH_OOPS(...) do { fprintf(stderr, __VA_ARGS__); exit(-1); } while (0)
+#define HASH_FSCK(hh,head,where)                                                 \
+do {                                                                             \
+  struct UT_hash_handle *_thh;                                                   \
+  if (head) {                                                                    \
+    unsigned _bkt_i;                                                             \
+    unsigned _count = 0;                                                         \
+    char *_prev;                                                                 \
+    for (_bkt_i = 0; _bkt_i < (head)->hh.tbl->num_buckets; ++_bkt_i) {           \
+      unsigned _bkt_count = 0;                                                   \
+      _thh = (head)->hh.tbl->buckets[_bkt_i].hh_head;                            \
+      _prev = NULL;                                                              \
+      while (_thh) {                                                             \
+        if (_prev != (char*)(_thh->hh_prev)) {                                   \
+          HASH_OOPS("%s: invalid hh_prev %p, actual %p\n",                       \
+              (where), (void*)_thh->hh_prev, (void*)_prev);                      \
+        }                                                                        \
+        _bkt_count++;                                                            \
+        _prev = (char*)(_thh);                                                   \
+        _thh = _thh->hh_next;                                                    \
+      }                                                                          \
+      _count += _bkt_count;                                                      \
+      if ((head)->hh.tbl->buckets[_bkt_i].count !=  _bkt_count) {                \
+        HASH_OOPS("%s: invalid bucket count %u, actual %u\n",                    \
+            (where), (head)->hh.tbl->buckets[_bkt_i].count, _bkt_count);         \
+      }                                                                          \
+    }                                                                            \
+    if (_count != (head)->hh.tbl->num_items) {                                   \
+      HASH_OOPS("%s: invalid hh item count %u, actual %u\n",                     \
+          (where), (head)->hh.tbl->num_items, _count);                           \
+    }                                                                            \
+    _count = 0;                                                                  \
+    _prev = NULL;                                                                \
+    _thh =  &(head)->hh;                                                         \
+    while (_thh) {                                                               \
+      _count++;                                                                  \
+      if (_prev != (char*)_thh->prev) {                                          \
+        HASH_OOPS("%s: invalid prev %p, actual %p\n",                            \
+            (where), (void*)_thh->prev, (void*)_prev);                           \
+      }                                                                          \
+      _prev = (char*)ELMT_FROM_HH((head)->hh.tbl, _thh);                         \
+      _thh = (_thh->next ? HH_FROM_ELMT((head)->hh.tbl, _thh->next) : NULL);     \
+    }                                                                            \
+    if (_count != (head)->hh.tbl->num_items) {                                   \
+      HASH_OOPS("%s: invalid app item count %u, actual %u\n",                    \
+          (where), (head)->hh.tbl->num_items, _count);                           \
+    }                                                                            \
+  }                                                                              \
+} while (0)
+#else
+#define HASH_FSCK(hh,head,where)
+#endif
+
+/* When compiled with -DHASH_EMIT_KEYS, length-prefixed keys are emitted to
+ * the descriptor to which this macro is defined for tuning the hash function.
+ * The app can #include <unistd.h> to get the prototype for write(2). */
+#ifdef HASH_EMIT_KEYS
+#define HASH_EMIT_KEY(hh,head,keyptr,fieldlen)                                   \
+do {                                                                             \
+  unsigned _klen = fieldlen;                                                     \
+  write(HASH_EMIT_KEYS, &_klen, sizeof(_klen));                                  \
+  write(HASH_EMIT_KEYS, keyptr, (unsigned long)fieldlen);                        \
+} while (0)
+#else
+#define HASH_EMIT_KEY(hh,head,keyptr,fieldlen)
+#endif
+
+/* The Bernstein hash function, used in Perl prior to v5.6. Note (x<<5+x)=x*33. */
+#define HASH_BER(key,keylen,hashv)                                               \
+do {                                                                             \
+  unsigned _hb_keylen = (unsigned)keylen;                                        \
+  const unsigned char *_hb_key = (const unsigned char*)(key);                    \
+  (hashv) = 0;                                                                   \
+  while (_hb_keylen-- != 0U) {                                                   \
+    (hashv) = (((hashv) << 5) + (hashv)) + *_hb_key++;                           \
+  }                                                                              \
+} while (0)
+
+
+/* SAX/FNV/OAT/JEN hash functions are macro variants of those listed at
+ * http://eternallyconfuzzled.com/tuts/algorithms/jsw_tut_hashing.aspx
+ * (archive link: https://archive.is/Ivcan )
+ */
+#define HASH_SAX(key,keylen,hashv)                                               \
+do {                                                                             \
+  unsigned _sx_i;                                                                \
+  const unsigned char *_hs_key = (const unsigned char*)(key);                    \
+  hashv = 0;                                                                     \
+  for (_sx_i=0; _sx_i < keylen; _sx_i++) {                                       \
+    hashv ^= (hashv << 5) + (hashv >> 2) + _hs_key[_sx_i];                       \
+  }                                                                              \
+} while (0)
+/* FNV-1a variation */
+#define HASH_FNV(key,keylen,hashv)                                               \
+do {                                                                             \
+  unsigned _fn_i;                                                                \
+  const unsigned char *_hf_key = (const unsigned char*)(key);                    \
+  (hashv) = 2166136261U;                                                         \
+  for (_fn_i=0; _fn_i < keylen; _fn_i++) {                                       \
+    hashv = hashv ^ _hf_key[_fn_i];                                              \
+    hashv = hashv * 16777619U;                                                   \
+  }                                                                              \
+} while (0)
+
+#define HASH_OAT(key,keylen,hashv)                                               \
+do {                                                                             \
+  unsigned _ho_i;                                                                \
+  const unsigned char *_ho_key=(const unsigned char*)(key);                      \
+  hashv = 0;                                                                     \
+  for(_ho_i=0; _ho_i < keylen; _ho_i++) {                                        \
+      hashv += _ho_key[_ho_i];                                                   \
+      hashv += (hashv << 10);                                                    \
+      hashv ^= (hashv >> 6);                                                     \
+  }                                                                              \
+  hashv += (hashv << 3);                                                         \
+  hashv ^= (hashv >> 11);                                                        \
+  hashv += (hashv << 15);                                                        \
+} while (0)
+
+#define HASH_JEN_MIX(a,b,c)                                                      \
+do {                                                                             \
+  a -= b; a -= c; a ^= ( c >> 13 );                                              \
+  b -= c; b -= a; b ^= ( a << 8 );                                               \
+  c -= a; c -= b; c ^= ( b >> 13 );                                              \
+  a -= b; a -= c; a ^= ( c >> 12 );                                              \
+  b -= c; b -= a; b ^= ( a << 16 );                                              \
+  c -= a; c -= b; c ^= ( b >> 5 );                                               \
+  a -= b; a -= c; a ^= ( c >> 3 );                                               \
+  b -= c; b -= a; b ^= ( a << 10 );                                              \
+  c -= a; c -= b; c ^= ( b >> 15 );                                              \
+} while (0)
+
+#define HASH_JEN(key,keylen,hashv)                                               \
+do {                                                                             \
+  unsigned _hj_i,_hj_j,_hj_k;                                                    \
+  unsigned const char *_hj_key=(unsigned const char*)(key);                      \
+  hashv = 0xfeedbeefu;                                                           \
+  _hj_i = _hj_j = 0x9e3779b9u;                                                   \
+  _hj_k = (unsigned)(keylen);                                                    \
+  while (_hj_k >= 12U) {                                                         \
+    _hj_i +=    (_hj_key[0] + ( (unsigned)_hj_key[1] << 8 )                      \
+        + ( (unsigned)_hj_key[2] << 16 )                                         \
+        + ( (unsigned)_hj_key[3] << 24 ) );                                      \
+    _hj_j +=    (_hj_key[4] + ( (unsigned)_hj_key[5] << 8 )                      \
+        + ( (unsigned)_hj_key[6] << 16 )                                         \
+        + ( (unsigned)_hj_key[7] << 24 ) );                                      \
+    hashv += (_hj_key[8] + ( (unsigned)_hj_key[9] << 8 )                         \
+        + ( (unsigned)_hj_key[10] << 16 )                                        \
+        + ( (unsigned)_hj_key[11] << 24 ) );                                     \
+                                                                                 \
+     HASH_JEN_MIX(_hj_i, _hj_j, hashv);                                          \
+                                                                                 \
+     _hj_key += 12;                                                              \
+     _hj_k -= 12U;                                                               \
+  }                                                                              \
+  hashv += (unsigned)(keylen);                                                   \
+  switch ( _hj_k ) {                                                             \
+    case 11: hashv += ( (unsigned)_hj_key[10] << 24 ); /* FALLTHROUGH */         \
+    case 10: hashv += ( (unsigned)_hj_key[9] << 16 );  /* FALLTHROUGH */         \
+    case 9:  hashv += ( (unsigned)_hj_key[8] << 8 );   /* FALLTHROUGH */         \
+    case 8:  _hj_j += ( (unsigned)_hj_key[7] << 24 );  /* FALLTHROUGH */         \
+    case 7:  _hj_j += ( (unsigned)_hj_key[6] << 16 );  /* FALLTHROUGH */         \
+    case 6:  _hj_j += ( (unsigned)_hj_key[5] << 8 );   /* FALLTHROUGH */         \
+    case 5:  _hj_j += _hj_key[4];                      /* FALLTHROUGH */         \
+    case 4:  _hj_i += ( (unsigned)_hj_key[3] << 24 );  /* FALLTHROUGH */         \
+    case 3:  _hj_i += ( (unsigned)_hj_key[2] << 16 );  /* FALLTHROUGH */         \
+    case 2:  _hj_i += ( (unsigned)_hj_key[1] << 8 );   /* FALLTHROUGH */         \
+    case 1:  _hj_i += _hj_key[0];                      /* FALLTHROUGH */         \
+    default: ;                                                                   \
+  }                                                                              \
+  HASH_JEN_MIX(_hj_i, _hj_j, hashv);                                             \
+} while (0)
+
+/* The Paul Hsieh hash function */
+#undef get16bits
+#if (defined(__GNUC__) && defined(__i386__)) || defined(__WATCOMC__)             \
+  || defined(_MSC_VER) || defined (__BORLANDC__) || defined (__TURBOC__)
+#define get16bits(d) (*((const uint16_t *) (d)))
+#endif
+
+#if !defined (get16bits)
+#define get16bits(d) ((((uint32_t)(((const uint8_t *)(d))[1])) << 8)             \
+                       +(uint32_t)(((const uint8_t *)(d))[0]) )
+#endif
+#define HASH_SFH(key,keylen,hashv)                                               \
+do {                                                                             \
+  unsigned const char *_sfh_key=(unsigned const char*)(key);                     \
+  uint32_t _sfh_tmp, _sfh_len = (uint32_t)keylen;                                \
+                                                                                 \
+  unsigned _sfh_rem = _sfh_len & 3U;                                             \
+  _sfh_len >>= 2;                                                                \
+  hashv = 0xcafebabeu;                                                           \
+                                                                                 \
+  /* Main loop */                                                                \
+  for (;_sfh_len > 0U; _sfh_len--) {                                             \
+    hashv    += get16bits (_sfh_key);                                            \
+    _sfh_tmp  = ((uint32_t)(get16bits (_sfh_key+2)) << 11) ^ hashv;              \
+    hashv     = (hashv << 16) ^ _sfh_tmp;                                        \
+    _sfh_key += 2U*sizeof (uint16_t);                                            \
+    hashv    += hashv >> 11;                                                     \
+  }                                                                              \
+                                                                                 \
+  /* Handle end cases */                                                         \
+  switch (_sfh_rem) {                                                            \
+    case 3: hashv += get16bits (_sfh_key);                                       \
+            hashv ^= hashv << 16;                                                \
+            hashv ^= (uint32_t)(_sfh_key[sizeof (uint16_t)]) << 18;              \
+            hashv += hashv >> 11;                                                \
+            break;                                                               \
+    case 2: hashv += get16bits (_sfh_key);                                       \
+            hashv ^= hashv << 11;                                                \
+            hashv += hashv >> 17;                                                \
+            break;                                                               \
+    case 1: hashv += *_sfh_key;                                                  \
+            hashv ^= hashv << 10;                                                \
+            hashv += hashv >> 1;                                                 \
+            break;                                                               \
+    default: ;                                                                   \
+  }                                                                              \
+                                                                                 \
+  /* Force "avalanching" of final 127 bits */                                    \
+  hashv ^= hashv << 3;                                                           \
+  hashv += hashv >> 5;                                                           \
+  hashv ^= hashv << 4;                                                           \
+  hashv += hashv >> 17;                                                          \
+  hashv ^= hashv << 25;                                                          \
+  hashv += hashv >> 6;                                                           \
+} while (0)
+
+/* iterate over items in a known bucket to find desired item */
+#define HASH_FIND_IN_BKT(tbl,hh,head,keyptr,keylen_in,hashval,out)               \
+do {                                                                             \
+  if ((head).hh_head != NULL) {                                                  \
+    DECLTYPE_ASSIGN(out, ELMT_FROM_HH(tbl, (head).hh_head));                     \
+  } else {                                                                       \
+    (out) = NULL;                                                                \
+  }                                                                              \
+  while ((out) != NULL) {                                                        \
+    if ((out)->hh.hashv == (hashval) && (out)->hh.keylen == (keylen_in)) {       \
+      if (HASH_KEYCMP((out)->hh.key, keyptr, keylen_in) == 0) {                  \
+        break;                                                                   \
+      }                                                                          \
+    }                                                                            \
+    if ((out)->hh.hh_next != NULL) {                                             \
+      DECLTYPE_ASSIGN(out, ELMT_FROM_HH(tbl, (out)->hh.hh_next));                \
+    } else {                                                                     \
+      (out) = NULL;                                                              \
+    }                                                                            \
+  }                                                                              \
+} while (0)
+
+/* add an item to a bucket  */
+#define HASH_ADD_TO_BKT(head,hh,addhh,oomed)                                     \
+do {                                                                             \
+  UT_hash_bucket *_ha_head = &(head);                                            \
+  _ha_head->count++;                                                             \
+  (addhh)->hh_next = _ha_head->hh_head;                                          \
+  (addhh)->hh_prev = NULL;                                                       \
+  if (_ha_head->hh_head != NULL) {                                               \
+    _ha_head->hh_head->hh_prev = (addhh);                                        \
+  }                                                                              \
+  _ha_head->hh_head = (addhh);                                                   \
+  if ((_ha_head->count >= ((_ha_head->expand_mult + 1U) * HASH_BKT_CAPACITY_THRESH)) \
+      && !(addhh)->tbl->noexpand) {                                              \
+    HASH_EXPAND_BUCKETS(addhh,(addhh)->tbl, oomed);                              \
+    IF_HASH_NONFATAL_OOM(                                                        \
+      if (oomed) {                                                               \
+        HASH_DEL_IN_BKT(head,addhh);                                             \
+      }                                                                          \
+    )                                                                            \
+  }                                                                              \
+} while (0)
+
+/* remove an item from a given bucket */
+#define HASH_DEL_IN_BKT(head,delhh)                                              \
+do {                                                                             \
+  UT_hash_bucket *_hd_head = &(head);                                            \
+  _hd_head->count--;                                                             \
+  if (_hd_head->hh_head == (delhh)) {                                            \
+    _hd_head->hh_head = (delhh)->hh_next;                                        \
+  }                                                                              \
+  if ((delhh)->hh_prev) {                                                        \
+    (delhh)->hh_prev->hh_next = (delhh)->hh_next;                                \
+  }                                                                              \
+  if ((delhh)->hh_next) {                                                        \
+    (delhh)->hh_next->hh_prev = (delhh)->hh_prev;                                \
+  }                                                                              \
+} while (0)
+
+/* Bucket expansion has the effect of doubling the number of buckets
+ * and redistributing the items into the new buckets. Ideally the
+ * items will distribute more or less evenly into the new buckets
+ * (the extent to which this is true is a measure of the quality of
+ * the hash function as it applies to the key domain).
+ *
+ * With the items distributed into more buckets, the chain length
+ * (item count) in each bucket is reduced. Thus by expanding buckets
+ * the hash keeps a bound on the chain length. This bounded chain
+ * length is the essence of how a hash provides constant time lookup.
+ *
+ * The calculation of tbl->ideal_chain_maxlen below deserves some
+ * explanation. First, keep in mind that we're calculating the ideal
+ * maximum chain length based on the *new* (doubled) bucket count.
+ * In fractions this is just n/b (n=number of items,b=new num buckets).
+ * Since the ideal chain length is an integer, we want to calculate
+ * ceil(n/b). We don't depend on floating point arithmetic in this
+ * hash, so to calculate ceil(n/b) with integers we could write
+ *
+ *      ceil(n/b) = (n/b) + ((n%b)?1:0)
+ *
+ * and in fact a previous version of this hash did just that.
+ * But now we have improved things a bit by recognizing that b is
+ * always a power of two. We keep its base 2 log handy (call it lb),
+ * so now we can write this with a bit shift and logical AND:
+ *
+ *      ceil(n/b) = (n>>lb) + ( (n & (b-1)) ? 1:0)
+ *
+ */
+#define HASH_EXPAND_BUCKETS(hh,tbl,oomed)                                        \
+do {                                                                             \
+  unsigned _he_bkt;                                                              \
+  unsigned _he_bkt_i;                                                            \
+  struct UT_hash_handle *_he_thh, *_he_hh_nxt;                                   \
+  UT_hash_bucket *_he_new_buckets, *_he_newbkt;                                  \
+  _he_new_buckets = (UT_hash_bucket*)uthash_malloc(                              \
+           sizeof(struct UT_hash_bucket) * (tbl)->num_buckets * 2U);             \
+  if (!_he_new_buckets) {                                                        \
+    HASH_RECORD_OOM(oomed);                                                      \
+  } else {                                                                       \
+    uthash_bzero(_he_new_buckets,                                                \
+        sizeof(struct UT_hash_bucket) * (tbl)->num_buckets * 2U);                \
+    (tbl)->ideal_chain_maxlen =                                                  \
+       ((tbl)->num_items >> ((tbl)->log2_num_buckets+1U)) +                      \
+       ((((tbl)->num_items & (((tbl)->num_buckets*2U)-1U)) != 0U) ? 1U : 0U);    \
+    (tbl)->nonideal_items = 0;                                                   \
+    for (_he_bkt_i = 0; _he_bkt_i < (tbl)->num_buckets; _he_bkt_i++) {           \
+      _he_thh = (tbl)->buckets[ _he_bkt_i ].hh_head;                             \
+      while (_he_thh != NULL) {                                                  \
+        _he_hh_nxt = _he_thh->hh_next;                                           \
+        HASH_TO_BKT(_he_thh->hashv, (tbl)->num_buckets * 2U, _he_bkt);           \
+        _he_newbkt = &(_he_new_buckets[_he_bkt]);                                \
+        if (++(_he_newbkt->count) > (tbl)->ideal_chain_maxlen) {                 \
+          (tbl)->nonideal_items++;                                               \
+          if (_he_newbkt->count > _he_newbkt->expand_mult * (tbl)->ideal_chain_maxlen) { \
+            _he_newbkt->expand_mult++;                                           \
+          }                                                                      \
+        }                                                                        \
+        _he_thh->hh_prev = NULL;                                                 \
+        _he_thh->hh_next = _he_newbkt->hh_head;                                  \
+        if (_he_newbkt->hh_head != NULL) {                                       \
+          _he_newbkt->hh_head->hh_prev = _he_thh;                                \
+        }                                                                        \
+        _he_newbkt->hh_head = _he_thh;                                           \
+        _he_thh = _he_hh_nxt;                                                    \
+      }                                                                          \
+    }                                                                            \
+    uthash_free((tbl)->buckets, (tbl)->num_buckets * sizeof(struct UT_hash_bucket)); \
+    (tbl)->num_buckets *= 2U;                                                    \
+    (tbl)->log2_num_buckets++;                                                   \
+    (tbl)->buckets = _he_new_buckets;                                            \
+    (tbl)->ineff_expands = ((tbl)->nonideal_items > ((tbl)->num_items >> 1)) ?   \
+        ((tbl)->ineff_expands+1U) : 0U;                                          \
+    if ((tbl)->ineff_expands > 1U) {                                             \
+      (tbl)->noexpand = 1;                                                       \
+      uthash_noexpand_fyi(tbl);                                                  \
+    }                                                                            \
+    uthash_expand_fyi(tbl);                                                      \
+  }                                                                              \
+} while (0)
+
+
+/* This is an adaptation of Simon Tatham's O(n log(n)) mergesort */
+/* Note that HASH_SORT assumes the hash handle name to be hh.
+ * HASH_SRT was added to allow the hash handle name to be passed in. */
+#define HASH_SORT(head,cmpfcn) HASH_SRT(hh,head,cmpfcn)
+#define HASH_SRT(hh,head,cmpfcn)                                                 \
+do {                                                                             \
+  unsigned _hs_i;                                                                \
+  unsigned _hs_looping,_hs_nmerges,_hs_insize,_hs_psize,_hs_qsize;               \
+  struct UT_hash_handle *_hs_p, *_hs_q, *_hs_e, *_hs_list, *_hs_tail;            \
+  if (head != NULL) {                                                            \
+    _hs_insize = 1;                                                              \
+    _hs_looping = 1;                                                             \
+    _hs_list = &((head)->hh);                                                    \
+    while (_hs_looping != 0U) {                                                  \
+      _hs_p = _hs_list;                                                          \
+      _hs_list = NULL;                                                           \
+      _hs_tail = NULL;                                                           \
+      _hs_nmerges = 0;                                                           \
+      while (_hs_p != NULL) {                                                    \
+        _hs_nmerges++;                                                           \
+        _hs_q = _hs_p;                                                           \
+        _hs_psize = 0;                                                           \
+        for (_hs_i = 0; _hs_i < _hs_insize; ++_hs_i) {                           \
+          _hs_psize++;                                                           \
+          _hs_q = ((_hs_q->next != NULL) ?                                       \
+            HH_FROM_ELMT((head)->hh.tbl, _hs_q->next) : NULL);                   \
+          if (_hs_q == NULL) {                                                   \
+            break;                                                               \
+          }                                                                      \
+        }                                                                        \
+        _hs_qsize = _hs_insize;                                                  \
+        while ((_hs_psize != 0U) || ((_hs_qsize != 0U) && (_hs_q != NULL))) {    \
+          if (_hs_psize == 0U) {                                                 \
+            _hs_e = _hs_q;                                                       \
+            _hs_q = ((_hs_q->next != NULL) ?                                     \
+              HH_FROM_ELMT((head)->hh.tbl, _hs_q->next) : NULL);                 \
+            _hs_qsize--;                                                         \
+          } else if ((_hs_qsize == 0U) || (_hs_q == NULL)) {                     \
+            _hs_e = _hs_p;                                                       \
+            if (_hs_p != NULL) {                                                 \
+              _hs_p = ((_hs_p->next != NULL) ?                                   \
+                HH_FROM_ELMT((head)->hh.tbl, _hs_p->next) : NULL);               \
+            }                                                                    \
+            _hs_psize--;                                                         \
+          } else if ((cmpfcn(                                                    \
+                DECLTYPE(head)(ELMT_FROM_HH((head)->hh.tbl, _hs_p)),             \
+                DECLTYPE(head)(ELMT_FROM_HH((head)->hh.tbl, _hs_q))              \
+                )) <= 0) {                                                       \
+            _hs_e = _hs_p;                                                       \
+            if (_hs_p != NULL) {                                                 \
+              _hs_p = ((_hs_p->next != NULL) ?                                   \
+                HH_FROM_ELMT((head)->hh.tbl, _hs_p->next) : NULL);               \
+            }                                                                    \
+            _hs_psize--;                                                         \
+          } else {                                                               \
+            _hs_e = _hs_q;                                                       \
+            _hs_q = ((_hs_q->next != NULL) ?                                     \
+              HH_FROM_ELMT((head)->hh.tbl, _hs_q->next) : NULL);                 \
+            _hs_qsize--;                                                         \
+          }                                                                      \
+          if ( _hs_tail != NULL ) {                                              \
+            _hs_tail->next = ((_hs_e != NULL) ?                                  \
+              ELMT_FROM_HH((head)->hh.tbl, _hs_e) : NULL);                       \
+          } else {                                                               \
+            _hs_list = _hs_e;                                                    \
+          }                                                                      \
+          if (_hs_e != NULL) {                                                   \
+            _hs_e->prev = ((_hs_tail != NULL) ?                                  \
+              ELMT_FROM_HH((head)->hh.tbl, _hs_tail) : NULL);                    \
+          }                                                                      \
+          _hs_tail = _hs_e;                                                      \
+        }                                                                        \
+        _hs_p = _hs_q;                                                           \
+      }                                                                          \
+      if (_hs_tail != NULL) {                                                    \
+        _hs_tail->next = NULL;                                                   \
+      }                                                                          \
+      if (_hs_nmerges <= 1U) {                                                   \
+        _hs_looping = 0;                                                         \
+        (head)->hh.tbl->tail = _hs_tail;                                         \
+        DECLTYPE_ASSIGN(head, ELMT_FROM_HH((head)->hh.tbl, _hs_list));           \
+      }                                                                          \
+      _hs_insize *= 2U;                                                          \
+    }                                                                            \
+    HASH_FSCK(hh, head, "HASH_SRT");                                             \
+  }                                                                              \
+} while (0)
+
+/* This function selects items from one hash into another hash.
+ * The end result is that the selected items have dual presence
+ * in both hashes. There is no copy of the items made; rather
+ * they are added into the new hash through a secondary hash
+ * hash handle that must be present in the structure. */
+#define HASH_SELECT(hh_dst, dst, hh_src, src, cond)                              \
+do {                                                                             \
+  unsigned _src_bkt, _dst_bkt;                                                   \
+  void *_last_elt = NULL, *_elt;                                                 \
+  UT_hash_handle *_src_hh, *_dst_hh, *_last_elt_hh=NULL;                         \
+  ptrdiff_t _dst_hho = ((char*)(&(dst)->hh_dst) - (char*)(dst));                 \
+  if ((src) != NULL) {                                                           \
+    for (_src_bkt=0; _src_bkt < (src)->hh_src.tbl->num_buckets; _src_bkt++) {    \
+      for (_src_hh = (src)->hh_src.tbl->buckets[_src_bkt].hh_head;               \
+        _src_hh != NULL;                                                         \
+        _src_hh = _src_hh->hh_next) {                                            \
+        _elt = ELMT_FROM_HH((src)->hh_src.tbl, _src_hh);                         \
+        if (cond(_elt)) {                                                        \
+          IF_HASH_NONFATAL_OOM( int _hs_oomed = 0; )                             \
+          _dst_hh = (UT_hash_handle*)(void*)(((char*)_elt) + _dst_hho);          \
+          _dst_hh->key = _src_hh->key;                                           \
+          _dst_hh->keylen = _src_hh->keylen;                                     \
+          _dst_hh->hashv = _src_hh->hashv;                                       \
+          _dst_hh->prev = _last_elt;                                             \
+          _dst_hh->next = NULL;                                                  \
+          if (_last_elt_hh != NULL) {                                            \
+            _last_elt_hh->next = _elt;                                           \
+          }                                                                      \
+          if ((dst) == NULL) {                                                   \
+            DECLTYPE_ASSIGN(dst, _elt);                                          \
+            HASH_MAKE_TABLE(hh_dst, dst, _hs_oomed);                             \
+            IF_HASH_NONFATAL_OOM(                                                \
+              if (_hs_oomed) {                                                   \
+                uthash_nonfatal_oom(_elt);                                       \
+                (dst) = NULL;                                                    \
+                continue;                                                        \
+              }                                                                  \
+            )                                                                    \
+          } else {                                                               \
+            _dst_hh->tbl = (dst)->hh_dst.tbl;                                    \
+          }                                                                      \
+          HASH_TO_BKT(_dst_hh->hashv, _dst_hh->tbl->num_buckets, _dst_bkt);      \
+          HASH_ADD_TO_BKT(_dst_hh->tbl->buckets[_dst_bkt], hh_dst, _dst_hh, _hs_oomed); \
+          (dst)->hh_dst.tbl->num_items++;                                        \
+          IF_HASH_NONFATAL_OOM(                                                  \
+            if (_hs_oomed) {                                                     \
+              HASH_ROLLBACK_BKT(hh_dst, dst, _dst_hh);                           \
+              HASH_DELETE_HH(hh_dst, dst, _dst_hh);                              \
+              _dst_hh->tbl = NULL;                                               \
+              uthash_nonfatal_oom(_elt);                                         \
+              continue;                                                          \
+            }                                                                    \
+          )                                                                      \
+          HASH_BLOOM_ADD(_dst_hh->tbl, _dst_hh->hashv);                          \
+          _last_elt = _elt;                                                      \
+          _last_elt_hh = _dst_hh;                                                \
+        }                                                                        \
+      }                                                                          \
+    }                                                                            \
+  }                                                                              \
+  HASH_FSCK(hh_dst, dst, "HASH_SELECT");                                         \
+} while (0)
+
+#define HASH_CLEAR(hh,head)                                                      \
+do {                                                                             \
+  if ((head) != NULL) {                                                          \
+    HASH_BLOOM_FREE((head)->hh.tbl);                                             \
+    uthash_free((head)->hh.tbl->buckets,                                         \
+                (head)->hh.tbl->num_buckets*sizeof(struct UT_hash_bucket));      \
+    uthash_free((head)->hh.tbl, sizeof(UT_hash_table));                          \
+    (head) = NULL;                                                               \
+  }                                                                              \
+} while (0)
+
+#define HASH_OVERHEAD(hh,head)                                                   \
+ (((head) != NULL) ? (                                                           \
+ (size_t)(((head)->hh.tbl->num_items   * sizeof(UT_hash_handle))   +             \
+          ((head)->hh.tbl->num_buckets * sizeof(UT_hash_bucket))   +             \
+           sizeof(UT_hash_table)                                   +             \
+           (HASH_BLOOM_BYTELEN))) : 0U)
+
+#ifdef NO_DECLTYPE
+#define HASH_ITER(hh,head,el,tmp)                                                \
+for(((el)=(head)), ((*(char**)(&(tmp)))=(char*)((head!=NULL)?(head)->hh.next:NULL)); \
+  (el) != NULL; ((el)=(tmp)), ((*(char**)(&(tmp)))=(char*)((tmp!=NULL)?(tmp)->hh.next:NULL)))
+#else
+#define HASH_ITER(hh,head,el,tmp)                                                \
+for(((el)=(head)), ((tmp)=DECLTYPE(el)((head!=NULL)?(head)->hh.next:NULL));      \
+  (el) != NULL; ((el)=(tmp)), ((tmp)=DECLTYPE(el)((tmp!=NULL)?(tmp)->hh.next:NULL)))
+#endif
+
+/* obtain a count of items in the hash */
+#define HASH_COUNT(head) HASH_CNT(hh,head)
+#define HASH_CNT(hh,head) ((head != NULL)?((head)->hh.tbl->num_items):0U)
+
+typedef struct UT_hash_bucket {
+   struct UT_hash_handle *hh_head;
+   unsigned count;
+
+   /* expand_mult is normally set to 0. In this situation, the max chain length
+    * threshold is enforced at its default value, HASH_BKT_CAPACITY_THRESH. (If
+    * the bucket's chain exceeds this length, bucket expansion is triggered).
+    * However, setting expand_mult to a non-zero value delays bucket expansion
+    * (that would be triggered by additions to this particular bucket)
+    * until its chain length reaches a *multiple* of HASH_BKT_CAPACITY_THRESH.
+    * (The multiplier is simply expand_mult+1). The whole idea of this
+    * multiplier is to reduce bucket expansions, since they are expensive, in
+    * situations where we know that a particular bucket tends to be overused.
+    * It is better to let its chain length grow to a longer yet-still-bounded
+    * value, than to do an O(n) bucket expansion too often.
+    */
+   unsigned expand_mult;
+
+} UT_hash_bucket;
+
+/* random signature used only to find hash tables in external analysis */
+#define HASH_SIGNATURE 0xa0111fe1u
+#define HASH_BLOOM_SIGNATURE 0xb12220f2u
+
+typedef struct UT_hash_table {
+   UT_hash_bucket *buckets;
+   unsigned num_buckets, log2_num_buckets;
+   unsigned num_items;
+   struct UT_hash_handle *tail; /* tail hh in app order, for fast append    */
+   ptrdiff_t hho; /* hash handle offset (byte pos of hash handle in element */
+
+   /* in an ideal situation (all buckets used equally), no bucket would have
+    * more than ceil(#items/#buckets) items. that's the ideal chain length. */
+   unsigned ideal_chain_maxlen;
+
+   /* nonideal_items is the number of items in the hash whose chain position
+    * exceeds the ideal chain maxlen. these items pay the penalty for an uneven
+    * hash distribution; reaching them in a chain traversal takes >ideal steps */
+   unsigned nonideal_items;
+
+   /* ineffective expands occur when a bucket doubling was performed, but
+    * afterward, more than half the items in the hash had nonideal chain
+    * positions. If this happens on two consecutive expansions we inhibit any
+    * further expansion, as it's not helping; this happens when the hash
+    * function isn't a good fit for the key domain. When expansion is inhibited
+    * the hash will still work, albeit no longer in constant time. */
+   unsigned ineff_expands, noexpand;
+
+   uint32_t signature; /* used only to find hash tables in external analysis */
+#ifdef HASH_BLOOM
+   uint32_t bloom_sig; /* used only to test bloom exists in external analysis */
+   uint8_t *bloom_bv;
+   uint8_t bloom_nbits;
+#endif
+
+} UT_hash_table;
+
+typedef struct UT_hash_handle {
+   struct UT_hash_table *tbl;
+   void *prev;                       /* prev element in app order      */
+   void *next;                       /* next element in app order      */
+   struct UT_hash_handle *hh_prev;   /* previous hh in bucket order    */
+   struct UT_hash_handle *hh_next;   /* next hh in bucket order        */
+   const void *key;                  /* ptr to enclosing struct's key  */
+   unsigned keylen;                  /* enclosing struct's key len     */
+   unsigned hashv;                   /* result of hash-fcn(key)        */
+} UT_hash_handle;
+
+#endif /* UTHASH_H */


### PR DESCRIPTION
## Summary
- add an MPI-based C application that distributes lyrics across processes to compute word and artist statistics while batching lyrics for sentiment analysis
- integrate a Python helper that can call a local Ollama model or fall back to a rule-based classifier for sentiment counts
- document project structure, build/run instructions, and performance metrics collection in the README and provide a Makefile

## Testing
- `make` *(fails: mpicc not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc1dd3e6908329a0cab43100b260ef