### PR TITLE
Version 4 - Add MPI analysis pipeline and sentiment classifier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+CC=mpicc
+CFLAGS=-O2 -Wall -Wextra -std=c11 -Iinclude
+LDFLAGS=
+
+SRC=$(wildcard src/*.c)
+OBJ=$(SRC:.c=.o)
+
+TARGET=mpi_spotify
+
+all: $(TARGET)
+
+$(TARGET): $(OBJ)
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+
+clean:
+	rm -f $(OBJ) $(TARGET)
+
+.PHONY: all clean

--- a/README.md
+++ b/README.md
@@ -1,10 +1,92 @@
 # Music-Analyst-AI
 
-Desenvolver uma aplicação em paralelo utilizando o MPI com C para processar em paralelo os dados referentes a músicas no Spotify (https://www.kaggle.com/datasets/notshrirang/spotify-million-song-dataset), o trabalho consistirá em obter três tipos de informação do dataset, sendo elas:
+Aplicação para análise paralela do dataset [Spotify Million Song](https://www.kaggle.com/datasets/notshrirang/spotify-million-song-dataset) utilizando MPI em C.
+O projeto entrega três componentes principais:
 
-1 - Contagem de palavras: Contar a aparição de cada palavra presente nas letras, este desafio irá compor 40% da nota do código.
-2 - Artistas com mais músicas: Encontrar os artistas com a maior quantidade de músicas, este desafio irá compor 40% da nota do código.
-3 - Classificação: Fazer a classificação entre "Positiva", "Neutra" e "Negativa" sobre a letra das músicas usando uma integração com um modelo local de linguagem, após a classificação deve ser contado o total de cada classe, para este desafio pode ser utilizado uma linguagem auxiliar, como o python, para fazer a chamada do LLM, além de um software para auxiliar na execução do modelo, como por exemplo o Ollama (https://ollama.com). Este desafio irá compor 20% da nota do código.
+1. **Contagem de palavras** nas letras das músicas.
+2. **Ranking dos artistas** com maior número de músicas.
+3. **Classificação de sentimento** (Positiva, Neutra ou Negativa) para cada letra através de integração com um LLM local (via [Ollama](https://ollama.com)) ou heurística de fallback.
 
-- Para a entrega anexar todos os arquivos necessários para executar a solução.
-- Calcular as métricas de desempenho da aplicação, analisando o que impactou o resultado.
+Além disso, são disponibilizadas métricas de desempenho para avaliar o impacto do paralelismo.
+
+## Estrutura do projeto
+
+```
+.
+├── docs/
+│   └── performance_analysis.md   # Guia para medições e análise de desempenho
+├── include/
+│   └── hashmap.h                 # Estruturas auxiliares de mapa hash
+├── scripts/
+│   └── classify_lyrics.py        # Classificação de sentimentos via LLM ou fallback
+├── src/
+│   ├── hashmap.c                 # Implementação da tabela hash
+│   └── mpi_spotify.c             # Aplicação principal em MPI
+├── Makefile                      # Processo de compilação com mpicc
+├── README.md                     # Este arquivo
+└── spotify_millsongdata.csv      # Dataset original (precisa estar presente)
+```
+
+## Pré-requisitos
+
+- [MPI](https://www.open-mpi.org/) (por exemplo, OpenMPI) com `mpicc`, `mpirun` ou `mpiexec`.
+- Compilador C compatível com C11.
+- Python 3.9+ para o script de classificação.
+- (Opcional) [Ollama](https://ollama.com) instalado localmente e configurado com um modelo adequado para sentimento (ex.: `llama3`).
+
+## Compilação
+
+```bash
+mpicc -O2 -Wall -Wextra -std=c11 -Iinclude -o mpi_spotify src/hashmap.c src/mpi_spotify.c
+```
+
+ou simplesmente:
+
+```bash
+make
+```
+
+## Execução da análise paralela
+
+```bash
+mpirun -np <numero_processos> ./mpi_spotify spotify_millsongdata.csv
+```
+
+A aplicação distribui cada linha do CSV entre os processos MPI, efetua a contagem local e consolida os resultados no *rank* 0. O processo principal imprime:
+
+- Top 20 palavras mais frequentes.
+- Top 20 artistas com mais músicas.
+- Métricas de tempo (mínimo, máximo e média) para processamento e tempo total por processo.
+
+## Classificação de sentimento com LLM
+
+O script `scripts/classify_lyrics.py` realiza a classificação de cada letra em três categorias.
+
+### Uso com Ollama
+
+```bash
+python3 scripts/classify_lyrics.py spotify_millsongdata.csv --modo ollama --modelo llama3 --limite 1000
+```
+
+- `--limite` é opcional para restringir a quantidade de músicas processadas (útil para testes iniciais).
+- Ajuste o nome do modelo conforme os modelos instalados no Ollama.
+
+### Modo de fallback
+
+Caso não haja um LLM disponível, utilize o modo `fallback`, que aplica uma heurística simples baseada em palavras-chave. Embora menos precisa, permite validar toda a tubulação do processo.
+
+```bash
+python3 scripts/classify_lyrics.py spotify_millsongdata.csv --modo fallback --limite 1000
+```
+
+O script mostra o total de músicas analisadas e a contagem por classe.
+
+## Métricas de desempenho
+
+O arquivo [`docs/performance_analysis.md`](docs/performance_analysis.md) descreve como coletar e interpretar as métricas emitidas pela aplicação MPI, além de sugerir abordagens para testes variando o número de processos, tamanho de amostras e características de hardware.
+
+## Observações
+
+- O dataset original contém cerca de um milhão de músicas. Para experimentos rápidos, considere criar subconjuntos menores (por exemplo, usando `head` ou ferramentas como `split`).
+- Certifique-se de que o arquivo CSV esteja codificado em UTF-8 para evitar problemas de leitura.
+- A classificação via LLM pode ser custosa; recomenda-se processar em lotes ou aplicar paralelismo adicional na camada Python caso necessário.

--- a/docs/performance_analysis.md
+++ b/docs/performance_analysis.md
@@ -1,0 +1,28 @@
+# Análise de Desempenho
+
+Este documento descreve como medir e interpretar as métricas de desempenho da aplicação MPI.
+
+## Métricas coletadas automaticamente
+
+Ao término da execução, o processo de *rank* 0 imprime:
+
+- **Tempo de processamento**: tempo decorrido desde o início até a conclusão do processamento local (antes do envio/recebimento das tabelas de contagem). São apresentados os valores máximo, mínimo e médio entre todos os processos.
+- **Tempo total**: tempo completo de execução em cada processo (incluindo sincronização e envio/recebimento de resultados). Também são exibidos máximo, mínimo e média.
+
+Essas métricas são úteis para identificar desequilíbrios na distribuição de trabalho, gargalos de comunicação ou contendas de E/S.
+
+## Recomendações para experimentos
+
+1. **Variação do número de processos**: execute o programa com diferentes valores de `-np` (por exemplo, 1, 2, 4, 8, 16) e compare as métricas. O ganho ideal deve apresentar redução no tempo máximo de processamento.
+2. **Amostragem do dataset**: use subconjuntos do CSV (por exemplo, `head -n 100000 spotify_millsongdata.csv > sample.csv`) para testar rapidamente e observar como o tempo cresce em relação ao volume de dados.
+3. **I/O vs CPU**: monitore a utilização de CPU e disco (via `htop`, `iostat`, etc.) durante a execução. Leituras sequenciais do CSV podem se tornar o gargalo em discos lentos.
+4. **Configuração de rede** (clusters): em ambientes distribuídos, avalie a latência e largura de banda da rede. A abordagem mestre-trabalhador usada aqui depende da comunicação ponto a ponto entre o *rank* 0 e os demais.
+
+## Possíveis otimizações futuras
+
+- **Leitura paralela** via MPI-IO para reduzir o gargalo do *rank* 0.
+- **Compactação/serialização binária** das tabelas de contagem para diminuir o volume de dados transmitidos.
+- **Balanceamento adaptativo**: permitir que processos solicitem novas linhas quando concluírem suas filas (modelo *work stealing*).
+- **Pré-processamento do CSV** para normalizar letras e artistas, reduzindo trabalho de sanitização.
+
+Documente sempre as condições de hardware, tamanho da amostra e número de processos para comparar execuções de forma justa.

--- a/include/hashmap.h
+++ b/include/hashmap.h
@@ -1,0 +1,29 @@
+#ifndef HASHMAP_H
+#define HASHMAP_H
+
+#include <stddef.h>
+
+typedef struct HashNode {
+    char *key;
+    long long value;
+    struct HashNode *next;
+} HashNode;
+
+typedef struct {
+    HashNode **buckets;
+    size_t capacity;
+    size_t size;
+} HashMap;
+
+typedef struct {
+    const char *key;
+    long long value;
+} KeyValue;
+
+void hashmap_init(HashMap *map, size_t capacity);
+void hashmap_free(HashMap *map);
+void hashmap_increment(HashMap *map, const char *key, long long delta);
+size_t hashmap_size(const HashMap *map);
+KeyValue *hashmap_to_array(const HashMap *map);
+
+#endif

--- a/scripts/classify_lyrics.py
+++ b/scripts/classify_lyrics.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Classify Spotify lyrics using a local LLM via Ollama or a rule-based fallback."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import subprocess
+import sys
+from collections import Counter
+from typing import Dict, Iterable, Tuple
+
+SENTIMENT_CLASSES = ("Positiva", "Neutra", "Negativa")
+
+PROMPT_TEMPLATE = """Classifique o sentimento geral da letra abaixo em uma única palavra: Positiva, Neutra ou Negativa.\nLetra:\n"""
+
+FALLBACK_POSITIVE = {
+    "love",
+    "happy",
+    "smile",
+    "wonderful",
+    "joy",
+    "beautiful",
+    "sunshine",
+    "dance",
+}
+FALLBACK_NEGATIVE = {
+    "sad",
+    "cry",
+    "lonely",
+    "pain",
+    "tears",
+    "hate",
+    "dark",
+    "broken",
+}
+
+
+def call_ollama(model: str, prompt: str) -> str:
+    """Call Ollama using subprocess and return the raw string output."""
+    try:
+        completed = subprocess.run(
+            ["ollama", "run", model, prompt],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        return completed.stdout.strip()
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            "Ollama não foi encontrado no PATH. Instale o Ollama ou forneça --modo fallback."
+        ) from exc
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(
+            f"Falha ao executar Ollama: {exc.stderr.strip() or exc}"
+        ) from exc
+
+
+def fallback_classify(text: str) -> str:
+    text_lower = text.lower()
+    score = 0
+    for token in text_lower.split():
+        token = ''.join(ch for ch in token if ch.isalpha())
+        if token in FALLBACK_POSITIVE:
+            score += 1
+        elif token in FALLBACK_NEGATIVE:
+            score -= 1
+    if score > 0:
+        return "Positiva"
+    if score < 0:
+        return "Negativa"
+    return "Neutra"
+
+
+def llm_classify(text: str, model: str) -> str:
+    raw = call_ollama(model, PROMPT_TEMPLATE + text)
+    cleaned = raw.strip().splitlines()[0].strip().lower()
+    mapping = {
+        "positiva": "Positiva",
+        "positivo": "Positiva",
+        "neutra": "Neutra",
+        "negativa": "Negativa",
+        "negativo": "Negativa",
+    }
+    return mapping.get(cleaned, "Neutra")
+
+
+def classify_dataset(
+    csv_path: str,
+    limit: int | None,
+    mode: str,
+    model: str,
+) -> Tuple[Counter, int]:
+    counts: Counter = Counter()
+    total = 0
+    with open(csv_path, newline='', encoding='utf-8') as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            lyrics = row.get('text') or ''
+            if mode == 'ollama':
+                label = llm_classify(lyrics, model)
+            else:
+                label = fallback_classify(lyrics)
+            counts[label] += 1
+            total += 1
+            if limit is not None and total >= limit:
+                break
+    return counts, total
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('csv', help='Caminho para spotify_millsongdata.csv')
+    parser.add_argument(
+        '--modo',
+        choices=('ollama', 'fallback'),
+        default='fallback',
+        help='Modo de classificação: usar Ollama (necessita instalação) ou heurística local.',
+    )
+    parser.add_argument(
+        '--modelo',
+        default='llama3',
+        help='Nome do modelo Ollama a ser utilizado quando --modo=ollama.',
+    )
+    parser.add_argument(
+        '--limite',
+        type=int,
+        default=None,
+        help='Limite opcional de músicas a classificar (para testes rápidos).',
+    )
+    args = parser.parse_args()
+
+    if args.modo == 'ollama':
+        print(f'Classificando com Ollama e modelo {args.modelo}...')
+    else:
+        print('Classificando com heurística local (fallback).')
+
+    try:
+        counts, total = classify_dataset(args.csv, args.limite, args.modo, args.modelo)
+    except RuntimeError as exc:
+        print(exc, file=sys.stderr)
+        return 1
+
+    print(f'Total de músicas classificadas: {total}')
+    for label in SENTIMENT_CLASSES:
+        print(f'{label}: {counts.get(label, 0)}')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/hashmap.c
+++ b/src/hashmap.c
@@ -1,0 +1,129 @@
+#include "hashmap.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#define INITIAL_CAPACITY 16384
+#define LOAD_FACTOR 0.75
+
+static unsigned long hash_string(const char *str) {
+    unsigned long hash = 5381;
+    int c;
+    while ((c = *str++) != 0) {
+        hash = ((hash << 5) + hash) + (unsigned char)c;
+    }
+    return hash;
+}
+
+static void hashmap_rehash(HashMap *map) {
+    size_t new_capacity = map->capacity * 2;
+    HashNode **new_buckets = calloc(new_capacity, sizeof(HashNode *));
+    if (!new_buckets) {
+        return;
+    }
+
+    for (size_t i = 0; i < map->capacity; ++i) {
+        HashNode *node = map->buckets[i];
+        while (node) {
+            HashNode *next = node->next;
+            unsigned long hash = hash_string(node->key) % new_capacity;
+            node->next = new_buckets[hash];
+            new_buckets[hash] = node;
+            node = next;
+        }
+    }
+
+    free(map->buckets);
+    map->buckets = new_buckets;
+    map->capacity = new_capacity;
+}
+
+void hashmap_init(HashMap *map, size_t capacity) {
+    size_t initial_capacity = capacity == 0 ? INITIAL_CAPACITY : capacity;
+    map->buckets = calloc(initial_capacity, sizeof(HashNode *));
+    map->capacity = map->buckets ? initial_capacity : 0;
+    map->size = 0;
+}
+
+void hashmap_free(HashMap *map) {
+    if (!map || !map->buckets) {
+        return;
+    }
+
+    for (size_t i = 0; i < map->capacity; ++i) {
+        HashNode *node = map->buckets[i];
+        while (node) {
+            HashNode *next = node->next;
+            free(node->key);
+            free(node);
+            node = next;
+        }
+    }
+
+    free(map->buckets);
+    map->buckets = NULL;
+    map->capacity = 0;
+    map->size = 0;
+}
+
+void hashmap_increment(HashMap *map, const char *key, long long delta) {
+    if (!map || !map->buckets || !key) {
+        return;
+    }
+
+    unsigned long hash = hash_string(key) % map->capacity;
+    HashNode *node = map->buckets[hash];
+    while (node) {
+        if (strcmp(node->key, key) == 0) {
+            node->value += delta;
+            return;
+        }
+        node = node->next;
+    }
+
+    HashNode *new_node = malloc(sizeof(HashNode));
+    if (!new_node) {
+        return;
+    }
+    new_node->key = strdup(key);
+    if (!new_node->key) {
+        free(new_node);
+        return;
+    }
+    new_node->value = delta;
+    new_node->next = map->buckets[hash];
+    map->buckets[hash] = new_node;
+    map->size++;
+
+    if ((double)map->size / (double)map->capacity > LOAD_FACTOR) {
+        hashmap_rehash(map);
+    }
+}
+
+size_t hashmap_size(const HashMap *map) {
+    return map ? map->size : 0;
+}
+
+KeyValue *hashmap_to_array(const HashMap *map) {
+    if (!map || !map->buckets) {
+        return NULL;
+    }
+
+    KeyValue *array = malloc(map->size * sizeof(KeyValue));
+    if (!array) {
+        return NULL;
+    }
+
+    size_t index = 0;
+    for (size_t i = 0; i < map->capacity; ++i) {
+        HashNode *node = map->buckets[i];
+        while (node) {
+            array[index].key = node->key;
+            array[index].value = node->value;
+            ++index;
+            node = node->next;
+        }
+    }
+
+    return array;
+}

--- a/src/mpi_spotify.c
+++ b/src/mpi_spotify.c
@@ -1,0 +1,372 @@
+#include <ctype.h>
+#include <mpi.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "hashmap.h"
+
+#define TAG_LINE_LENGTH 1
+#define TAG_LINE_DATA 2
+#define TAG_WORD_COUNT 3
+#define TAG_ARTIST_COUNT 4
+
+#define MAX_TOP_RESULTS 20
+
+static void trim_newline(char *str) {
+    if (!str) {
+        return;
+    }
+    size_t len = strlen(str);
+    while (len > 0 && (str[len - 1] == '\n' || str[len - 1] == '\r')) {
+        str[len - 1] = '\0';
+        --len;
+    }
+}
+
+static void to_lowercase(char *str) {
+    if (!str) {
+        return;
+    }
+    for (size_t i = 0; str[i] != '\0'; ++i) {
+        str[i] = (char)tolower((unsigned char)str[i]);
+    }
+}
+
+static void sanitize_lyrics(char *lyrics) {
+    if (!lyrics) {
+        return;
+    }
+    for (size_t i = 0; lyrics[i] != '\0'; ++i) {
+        unsigned char ch = (unsigned char)lyrics[i];
+        if (!isalnum(ch) && ch != '\'' && ch != ' ') {
+            lyrics[i] = ' ';
+        }
+    }
+}
+
+static bool parse_csv_line(const char *line, char **artist_out, char **lyrics_out) {
+    if (!line || !artist_out || !lyrics_out) {
+        return false;
+    }
+
+    size_t length = strlen(line);
+    char *buffer = malloc(length + 1);
+    if (!buffer) {
+        return false;
+    }
+    strcpy(buffer, line);
+
+    char *fields[4] = {0};
+    size_t field_index = 0;
+    char *token = malloc(length + 1);
+    if (!token) {
+        free(buffer);
+        return false;
+    }
+
+    size_t token_index = 0;
+    bool in_quotes = false;
+    for (size_t i = 0; i <= length; ++i) {
+        char ch = buffer[i];
+        bool is_end = (ch == '\0');
+        if (ch == '"') {
+            in_quotes = !in_quotes;
+            continue;
+        }
+        if ((ch == ',' && !in_quotes) || is_end) {
+            token[token_index] = '\0';
+            fields[field_index++] = strdup(token);
+            token_index = 0;
+            if (field_index >= 4) {
+                break;
+            }
+            continue;
+        }
+        if (ch == '\r' || ch == '\n') {
+            continue;
+        }
+        token[token_index++] = ch;
+    }
+
+    free(buffer);
+    free(token);
+
+    if (field_index < 4) {
+        for (size_t i = 0; i < field_index; ++i) {
+            free(fields[i]);
+        }
+        return false;
+    }
+
+    *artist_out = fields[0];
+    *lyrics_out = fields[3];
+    free(fields[1]);
+    free(fields[2]);
+    return true;
+}
+
+static void free_parsed_fields(char *artist, char *lyrics) {
+    free(artist);
+    free(lyrics);
+}
+
+static void process_lyrics(const char *lyrics, HashMap *word_map) {
+    if (!lyrics) {
+        return;
+    }
+    char *normalized = strdup(lyrics);
+    if (!normalized) {
+        return;
+    }
+    to_lowercase(normalized);
+    sanitize_lyrics(normalized);
+
+    char *save_ptr = NULL;
+    char *token = strtok_r(normalized, " ", &save_ptr);
+    while (token) {
+        if (strlen(token) > 0) {
+            hashmap_increment(word_map, token, 1);
+        }
+        token = strtok_r(NULL, " ", &save_ptr);
+    }
+
+    free(normalized);
+}
+
+static void process_line(const char *line, HashMap *word_map, HashMap *artist_map) {
+    char *artist = NULL;
+    char *lyrics = NULL;
+    if (!parse_csv_line(line, &artist, &lyrics)) {
+        return;
+    }
+
+    trim_newline(artist);
+    trim_newline(lyrics);
+    to_lowercase(artist);
+
+    if (artist && strlen(artist) > 0) {
+        hashmap_increment(artist_map, artist, 1);
+    }
+
+    process_lyrics(lyrics, word_map);
+    free_parsed_fields(artist, lyrics);
+}
+
+static void send_map(HashMap *map, int dest_rank, int tag_base) {
+    int entry_count = (int)hashmap_size(map);
+    MPI_Send(&entry_count, 1, MPI_INT, dest_rank, tag_base, MPI_COMM_WORLD);
+    if (entry_count == 0) {
+        return;
+    }
+
+    KeyValue *entries = hashmap_to_array(map);
+    if (!entries) {
+        return;
+    }
+
+    for (int i = 0; i < entry_count; ++i) {
+        int key_length = (int)strlen(entries[i].key);
+        MPI_Send(&key_length, 1, MPI_INT, dest_rank, tag_base + 1, MPI_COMM_WORLD);
+        MPI_Send(entries[i].key, key_length, MPI_CHAR, dest_rank, tag_base + 2, MPI_COMM_WORLD);
+        MPI_Send(&entries[i].value, 1, MPI_LONG_LONG, dest_rank, tag_base + 3, MPI_COMM_WORLD);
+    }
+
+    free(entries);
+}
+
+static void receive_map(HashMap *map, int source_rank, int tag_base) {
+    int entry_count = 0;
+    MPI_Recv(&entry_count, 1, MPI_INT, source_rank, tag_base, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+    for (int i = 0; i < entry_count; ++i) {
+        int key_length = 0;
+        MPI_Recv(&key_length, 1, MPI_INT, source_rank, tag_base + 1, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+        char *key = malloc((size_t)key_length + 1);
+        if (!key) {
+            char *discard = malloc((size_t)key_length);
+            MPI_Recv(discard, key_length, MPI_CHAR, source_rank, tag_base + 2, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+            free(discard);
+            long long value;
+            MPI_Recv(&value, 1, MPI_LONG_LONG, source_rank, tag_base + 3, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+            continue;
+        }
+        MPI_Recv(key, key_length, MPI_CHAR, source_rank, tag_base + 2, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+        key[key_length] = '\0';
+        long long value = 0;
+        MPI_Recv(&value, 1, MPI_LONG_LONG, source_rank, tag_base + 3, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+        hashmap_increment(map, key, value);
+        free(key);
+    }
+}
+
+static int compare_desc(const void *a, const void *b) {
+    const KeyValue *left = (const KeyValue *)a;
+    const KeyValue *right = (const KeyValue *)b;
+    if (right->value > left->value) {
+        return 1;
+    }
+    if (right->value < left->value) {
+        return -1;
+    }
+    return strcmp(left->key, right->key);
+}
+
+static void print_top_results(const char *title, HashMap *map) {
+    size_t size = hashmap_size(map);
+    printf("\n%s (total %zu entradas)\n", title, size);
+    printf("----------------------------------------\n");
+    if (size == 0) {
+        return;
+    }
+
+    KeyValue *entries = hashmap_to_array(map);
+    if (!entries) {
+        return;
+    }
+    qsort(entries, size, sizeof(KeyValue), compare_desc);
+    size_t limit = size < MAX_TOP_RESULTS ? size : MAX_TOP_RESULTS;
+    for (size_t i = 0; i < limit; ++i) {
+        printf("%-30s %10lld\n", entries[i].key, entries[i].value);
+    }
+    free(entries);
+}
+
+static void broadcast_failure(int world_size) {
+    int terminate = -1;
+    for (int rank = 1; rank < world_size; ++rank) {
+        MPI_Send(&terminate, 1, MPI_INT, rank, TAG_LINE_LENGTH, MPI_COMM_WORLD);
+    }
+}
+
+int main(int argc, char **argv) {
+    MPI_Init(&argc, &argv);
+
+    int world_rank = 0;
+    int world_size = 0;
+    MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &world_size);
+
+    if (argc < 2) {
+        if (world_rank == 0) {
+            fprintf(stderr, "Uso: mpirun -np <processos> ./mpi_spotify <caminho_csv>\n");
+        }
+        MPI_Finalize();
+        return EXIT_FAILURE;
+    }
+
+    const char *csv_path = argv[1];
+
+    HashMap word_map;
+    HashMap artist_map;
+    hashmap_init(&word_map, 0);
+    hashmap_init(&artist_map, 0);
+
+    double start_time = MPI_Wtime();
+
+    if (world_rank == 0) {
+        FILE *file = fopen(csv_path, "r");
+        if (!file) {
+            perror("Erro ao abrir arquivo CSV");
+            broadcast_failure(world_size);
+            hashmap_free(&word_map);
+            hashmap_free(&artist_map);
+            MPI_Finalize();
+            return EXIT_FAILURE;
+        }
+
+        char *line = NULL;
+        size_t len = 0;
+        ssize_t read = getline(&line, &len, file); // header
+        (void)read;
+
+        long long line_index = 0;
+        while ((read = getline(&line, &len, file)) != -1) {
+            int target_rank = (int)(line_index % world_size);
+            if (target_rank == 0) {
+                process_line(line, &word_map, &artist_map);
+            } else {
+                int length = (int)strlen(line);
+                MPI_Send(&length, 1, MPI_INT, target_rank, TAG_LINE_LENGTH, MPI_COMM_WORLD);
+                MPI_Send(line, length, MPI_CHAR, target_rank, TAG_LINE_DATA, MPI_COMM_WORLD);
+            }
+            ++line_index;
+        }
+
+        free(line);
+        fclose(file);
+
+        int terminate = -1;
+        for (int rank = 1; rank < world_size; ++rank) {
+            MPI_Send(&terminate, 1, MPI_INT, rank, TAG_LINE_LENGTH, MPI_COMM_WORLD);
+        }
+    } else {
+        while (1) {
+            int length = 0;
+            MPI_Recv(&length, 1, MPI_INT, 0, TAG_LINE_LENGTH, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+            if (length == -1) {
+                break;
+            }
+            char *line = malloc((size_t)length + 1);
+            if (!line) {
+                char *discard = malloc((size_t)length);
+                MPI_Recv(discard, length, MPI_CHAR, 0, TAG_LINE_DATA, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                free(discard);
+                continue;
+            }
+            MPI_Recv(line, length, MPI_CHAR, 0, TAG_LINE_DATA, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+            line[length] = '\0';
+            process_line(line, &word_map, &artist_map);
+            free(line);
+        }
+    }
+
+    double processing_time = MPI_Wtime() - start_time;
+
+    if (world_rank == 0) {
+        for (int source = 1; source < world_size; ++source) {
+            receive_map(&word_map, source, TAG_WORD_COUNT);
+            receive_map(&artist_map, source, TAG_ARTIST_COUNT);
+        }
+    } else {
+        send_map(&word_map, 0, TAG_WORD_COUNT);
+        send_map(&artist_map, 0, TAG_ARTIST_COUNT);
+    }
+
+    double total_time = MPI_Wtime() - start_time;
+
+    double max_processing_time = 0.0;
+    double min_processing_time = 0.0;
+    double avg_processing_time = 0.0;
+    MPI_Reduce(&processing_time, &max_processing_time, 1, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
+    MPI_Reduce(&processing_time, &min_processing_time, 1, MPI_DOUBLE, MPI_MIN, 0, MPI_COMM_WORLD);
+    MPI_Reduce(&processing_time, &avg_processing_time, 1, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
+
+    double max_total_time = 0.0;
+    double min_total_time = 0.0;
+    double avg_total_time = 0.0;
+    MPI_Reduce(&total_time, &max_total_time, 1, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
+    MPI_Reduce(&total_time, &min_total_time, 1, MPI_DOUBLE, MPI_MIN, 0, MPI_COMM_WORLD);
+    MPI_Reduce(&total_time, &avg_total_time, 1, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
+
+    if (world_rank == 0) {
+        avg_processing_time /= world_size;
+        avg_total_time /= world_size;
+
+        print_top_results("Palavras mais frequentes", &word_map);
+        print_top_results("Artistas com mais músicas", &artist_map);
+
+        printf("\nMétricas de desempenho:\n");
+        printf("Tempo de processamento - máximo: %.3f s | mínimo: %.3f s | médio: %.3f s\n",
+               max_processing_time, min_processing_time, avg_processing_time);
+        printf("Tempo total - máximo: %.3f s | mínimo: %.3f s | médio: %.3f s\n",
+               max_total_time, min_total_time, avg_total_time);
+    }
+
+    hashmap_free(&word_map);
+    hashmap_free(&artist_map);
+
+    MPI_Finalize();
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary
- implement an MPI-based C application that counts lyric words and aggregates artists from the Spotify dataset
- add a reusable hash map helper, build scripts, and documentation for running the parallel analysis and measuring performance
- provide a Python classifier script that integrates with Ollama or a heuristic fallback to label lyrics as positive, neutral, or negative

## Testing
- python3 scripts/classify_lyrics.py spotify_millsongdata.csv --modo fallback --limite 5

------
https://chatgpt.com/codex/tasks/task_e_68dc1dd3e6908329a0cab43100b260ef