### PR TITLE
Version 1.5 - Parallelize standalone word count script with threads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+bin/
+output/
+__pycache__/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+MPICC ?= mpicc
+CFLAGS ?= -O2 -std=c11 -Wall -Wextra -Wpedantic
+
+SRC := src/parallel_spotify.c
+BIN := bin/parallel_spotify
+
+.PHONY: all clean
+
+all: $(BIN)
+
+$(BIN): $(SRC)
+	@mkdir -p $(dir $@)
+	$(MPICC) $(CFLAGS) -o $@ $^
+
+clean:
+	rm -rf bin output

--- a/README.md
+++ b/README.md
@@ -1,10 +1,161 @@
 # Music-Analyst-AI
 
-Desenvolver uma aplicação em paralelo utilizando o MPI com C para processar em paralelo os dados referentes a músicas no Spotify (https://www.kaggle.com/datasets/notshrirang/spotify-million-song-dataset), o trabalho consistirá em obter três tipos de informação do dataset, sendo elas:
+Aplicação paralela em C com MPI para processar o conjunto de dados
+[Spotify Million Song Dataset](https://www.kaggle.com/datasets/notshrirang/spotify-million-song-dataset).
+O objetivo é acelerar tarefas de análise exploratória das letras das músicas e
+fornecer integração com um modelo local de linguagem para classificação de
+sentimento.
 
-1 - Contagem de palavras: Contar a aparição de cada palavra presente nas letras, este desafio irá compor 40% da nota do código.
-2 - Artistas com mais músicas: Encontrar os artistas com a maior quantidade de músicas, este desafio irá compor 40% da nota do código.
-3 - Classificação: Fazer a classificação entre "Positiva", "Neutra" e "Negativa" sobre a letra das músicas usando uma integração com um modelo local de linguagem, após a classificação deve ser contado o total de cada classe, para este desafio pode ser utilizado uma linguagem auxiliar, como o python, para fazer a chamada do LLM, além de um software para auxiliar na execução do modelo, como por exemplo o Ollama (https://ollama.com). Este desafio irá compor 20% da nota do código.
+## Funcionalidades
 
-- Para a entrega anexar todos os arquivos necessários para executar a solução.
-- Calcular as métricas de desempenho da aplicação, analisando o que impactou o resultado.
+1. **Contagem de palavras** – o processo mestre separa o CSV original em
+   colunas independentes (artistas e letras) e cada processo MPI analisa uma
+   partição do arquivo de letras, mantendo contagens locais que posteriormente
+   são agregadas para produzir o ranking global das palavras mais frequentes.
+2. **Artistas com mais músicas** – em paralelo, os processos também percorrem o
+   arquivo de artistas gerado na etapa anterior e reportam os artistas mais
+   prolíficos.
+3. **Classificação de sentimento** – script auxiliar em Python permite enviar
+   as letras para um modelo local (por exemplo, via [Ollama](https://ollama.com))
+   e sumarizar o total de músicas Positivas, Neutras e Negativas.
+4. **Métricas de desempenho** – o executável MPI exporta métricas de tempo de
+   processamento e comunicação para análise comparativa entre diferentes
+   números de processos.
+5. **Contagem serial detalhada** – script independente permite gerar, sem uso
+   de MPI, a contagem total de palavras e o detalhamento por música para
+   consultas adicionais sem impactar as métricas do executável paralelo.
+
+## Pré-requisitos
+
+- Compilador e runtime MPI (`mpicc`, `mpirun`).
+- Python 3.9+ para a etapa de classificação com LLM.
+- (Opcional) Pacote `requests` para chamadas HTTP ao servidor do modelo.
+- (Opcional) Servidor Ollama ou outra solução que exponha um endpoint
+  compatível com `/api/generate`.
+
+## Compilação
+
+```bash
+make
+```
+
+O binário principal será gerado em `bin/parallel_spotify`.
+
+## Execução da análise paralela
+
+```bash
+mpirun -np <processos> ./bin/parallel_spotify spotify_millsongdata.csv \
+  [--word-limit N] [--artist-limit N] [--output-dir diretório]
+```
+
+Parâmetros opcionais:
+
+- `--word-limit`: limita o número de palavras escritas em `word_counts.csv`
+  (valor padrão: salvar **todas**; informe um número positivo para restringir).
+- `--artist-limit`: controla a quantidade de artistas exportados (padrão: salvar
+  **todos**; informe um número positivo para limitar).
+- `--output-dir`: diretório onde os artefatos são gerados (padrão: `output`).
+
+Ao final da execução são produzidos:
+
+- `word_counts.csv` – ranking decrescente de palavras.
+- `top_artists.csv` – artistas ordenados pela quantidade de músicas.
+- `performance_metrics.json` – tempos mínimo, médio e máximo por processo.
+- `split_columns/` – diretório auxiliar contendo os arquivos `artist.csv` e
+  `text.csv`, usados como insumos independentes para as contagens paralelas.
+
+## Classificação de sentimento com modelo local
+
+O script Python `scripts/sentiment_classifier.py` consome o mesmo dataset e
+consulta um modelo via HTTP. Ele pode operar em dois modos:
+
+1. **Modo real** (padrão) – envia requisições para um servidor compatível com
+   Ollama em `http://localhost:11434`. Ajuste a variável de ambiente
+   `OLLAMA_ENDPOINT` ou utilize `--model` para trocar o modelo.
+2. **Modo `--mock`** – aplica uma heurística simples baseada em palavras-chave
+   para facilitar testes sem LLM instalado.
+
+Exemplo de uso (modo real):
+
+```bash
+python scripts/sentiment_classifier.py spotify_millsongdata.csv \
+  --model llama3 --limit 200 --output-dir output
+```
+
+Modo simulado:
+
+```bash
+python scripts/sentiment_classifier.py spotify_millsongdata.csv --mock
+```
+
+Saídas geradas:
+
+- `sentiment_totals.json` – contagem agregada por classe.
+- `sentiment_details.csv` – detalhamento por música e tempo de inferência.
+
+## Medindo desempenho
+
+O arquivo `performance_metrics.json` produzido pelo executável MPI contém
+estatísticas de tempo médio, mínimo e máximo para cada estágio (cômputo local e
+tempo total). Para facilitar a comparação entre diferentes tamanhos de cluster,
+utilize o script `scripts/run_performance.sh`:
+
+```bash
+scripts/run_performance.sh spotify_millsongdata.csv 2 4 8
+```
+
+O script não recompila o projeto automaticamente; execute `make` antes de
+realizar os experimentos para garantir que o binário esteja atualizado.
+
+## Contagem serial de palavras por música
+
+Quando precisar analisar as letras de forma isolada, sem acionar o executável
+paralelo, utilize `scripts/word_count_per_song.py`. O script lê o CSV original,
+mantém as aspas e apóstrofos das letras e processa as músicas em paralelo com
+threads, gravando dois arquivos:
+
+- `word_counts_global.csv` – frequência total de cada palavra com três ou mais
+  caracteres.
+- `word_counts_by_song.csv` – frequência das palavras por artista e por música.
+
+Exemplo de uso:
+
+```bash
+python scripts/word_count_per_song.py spotify_millsongdata.csv \
+  --output-dir output/serial_word_counts --workers 8
+```
+
+O parâmetro `--workers` é opcional; quando omitido ou definido como zero, o
+script usa automaticamente o número de CPUs disponíveis.
+
+Os arquivos são gravados no diretório informado (padrão: `output/serial_word_counts`).
+
+## Estrutura do repositório
+
+```
+├── bin/parallel_spotify        # executável (gerado pelo make)
+├── output/                     # resultados (criado em tempo de execução)
+├── scripts/
+│   ├── run_performance.sh      # facilita execuções com vários processos
+│   ├── sentiment_classifier.py # classificação de sentimento com LLM local
+│   ├── split_csv_columns.py    # utilitário para dividir CSV em arquivos por coluna
+│   └── word_count_per_song.py  # contagem serial de palavras e detalhamento por música
+└── src/parallel_spotify.c      # código-fonte principal em C/MPI
+```
+
+## Histórico de versões
+
+| Versão | Descrição | Principais diferenças |
+| ------ | --------- | --------------------- |
+| v0.1 (`bdde614`) | Estrutura inicial do projeto. | Repositório criado com README mínimo e configuração base. |
+| v0.2 (`4f78f8e`, `732a70c`) | Detalhamento do enunciado. | README atualizado com os requisitos completos do trabalho prático. |
+| v0.3 (`293e8f8`) | Inclusão do dataset. | Arquivo `spotify_millsongdata.csv` adicionado para possibilitar testes locais. |
+| v1.0 (`8cc21fe`) – **versão atual** | Implementação paralela com MPI e pipeline de sentimento. | Código C distribuído, geração de métricas de desempenho, scripts auxiliares em Python e shell, documentação completa em português. |
+
+## Observações
+
+- Os arquivos CSV gerados podem ser grandes, pois por padrão incluem todos os
+  artistas e todas as palavras; ajuste `--word-limit` e `--artist-limit`
+  conforme necessário.
+- Certifique-se de apontar o `mpirun` para o mesmo `mpicc` utilizado na
+  compilação para evitar incompatibilidades de runtime.

--- a/scripts/run_performance.sh
+++ b/scripts/run_performance.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# Executa a aplicação MPI com diferentes quantidades de processos para coletar
+# métricas de desempenho. A documentação foi escrita em português conforme o
+# pedido do projeto.
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "Uso: $0 <dataset.csv> <quantidades_de_processos...>" >&2
+  exit 1
+fi
+
+data_file="$1"
+shift
+
+if [[ ! -f "$data_file" ]]; then
+  echo "Dataset não encontrado: $data_file" >&2
+  exit 1
+fi
+
+for np in "$@"; do
+  echo "== Executando com $np processos =="
+  mpirun -np "$np" ./bin/parallel_spotify "$data_file"
+  echo
+  sleep 1
+done

--- a/scripts/sentiment_classifier.py
+++ b/scripts/sentiment_classifier.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Classifica o sentimento das letras do Spotify usando um LLM local via Ollama.
+
+O script lê o dataset, envia cada letra para o modelo configurado e registra o
+total de previsões "Positive", "Neutral" e "Negative". O modo ``--mock`` evita
+chamadas reais ao modelo e utiliza uma heurística simples baseada em palavras,
+útil para testes automatizados ou quando o servidor Ollama não está acessível.
+
+Exemplo de uso::
+
+    python scripts/sentiment_classifier.py spotify_millsongdata.csv \
+        --model llama3 --limit 100 --output-dir output
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import sys
+import time
+from dataclasses import dataclass
+from typing import Dict, Iterable, Tuple
+
+try:
+    import requests
+except ImportError as exc:  # pragma: no cover - optional dependency
+    requests = None  # type: ignore
+
+
+PROMPT_TEMPLATE = """You are an expert music analyst. Classify the overall sentiment of the following song lyrics as one of the following labels: Positive, Neutral, or Negative. Respond using only the label name with no explanations.\n\nLyrics:\n{lyrics}\n"""
+
+DEFAULT_MODEL = "llama3"
+OLLAMA_ENDPOINT = os.environ.get("OLLAMA_ENDPOINT", "http://localhost:11434")
+SUPPORTED_LABELS = ("Positive", "Neutral", "Negative")
+
+
+@dataclass
+class ClassificationResult:
+    label: str
+    latency: float
+
+
+class SentimentClassifier:
+    """Encapsula a lógica de classificação de sentimento (real ou simulada)."""
+
+    def __init__(self, model: str, mock: bool = False) -> None:
+        """Configura o classificador indicando o modelo e se deve operar em modo mock."""
+        self.model = model
+        self.mock = mock
+        if not mock and requests is None:
+            raise RuntimeError(
+                "The 'requests' package is required for live classification. Install it or use --mock."
+            )
+
+    def classify(self, lyrics: str) -> ClassificationResult:
+        """Retorna a classe prevista para a letra fornecida."""
+        lyrics = lyrics.strip()
+        if not lyrics:
+            return ClassificationResult("Neutral", 0.0)
+        if self.mock:
+            return self._mock_classify(lyrics)
+        return self._ollama_classify(lyrics)
+
+    def _mock_classify(self, lyrics: str) -> ClassificationResult:
+        """Aplica uma heurística simples baseada em palavras positivas e negativas."""
+        lowered = lyrics.lower()
+        score = 0
+        positive_keywords = ("love", "happy", "joy", "sunshine", "smile")
+        negative_keywords = ("cry", "sad", "pain", "lonely", "tears")
+        for word in positive_keywords:
+            if word in lowered:
+                score += 1
+        for word in negative_keywords:
+            if word in lowered:
+                score -= 1
+        label = "Neutral"
+        if score > 0:
+            label = "Positive"
+        elif score < 0:
+            label = "Negative"
+        return ClassificationResult(label, 0.0)
+
+    def _ollama_classify(self, lyrics: str) -> ClassificationResult:
+        """Realiza a chamada HTTP ao servidor Ollama para obter a predição real."""
+        assert requests is not None  # for type checkers
+        payload = {
+            "model": self.model,
+            "prompt": PROMPT_TEMPLATE.format(lyrics=lyrics[:4000]),
+            "stream": False,
+        }
+        start = time.perf_counter()
+        response = requests.post(f"{OLLAMA_ENDPOINT}/api/generate", json=payload, timeout=120)
+        elapsed = time.perf_counter() - start
+        response.raise_for_status()
+        data = response.json()
+        raw_output = data.get("response", "").strip()
+        label = self._normalise_label(raw_output)
+        return ClassificationResult(label, elapsed)
+
+    @staticmethod
+    def _normalise_label(output: str) -> str:
+        """Normaliza a resposta do modelo garantindo que o rótulo seja suportado."""
+        cleaned = output.split()[0].strip().title()
+        if cleaned not in SUPPORTED_LABELS:
+            return "Neutral"
+        return cleaned
+
+
+def iter_lyrics(path: str, limit: int | None = None) -> Iterable[Tuple[str, str, str]]:
+    """Itera sobre o CSV retornando artista, música e letra (até o limite opcional)."""
+    with open(path, newline="", encoding="utf-8") as csv_file:
+        reader = csv.DictReader(csv_file)
+        for index, row in enumerate(reader):
+            if limit is not None and index >= limit:
+                break
+            yield row.get("artist", ""), row.get("song", ""), row.get("text", "")
+
+
+def ensure_output_dir(path: str) -> None:
+    """Garante que o diretório de saída exista antes de salvar os artefatos."""
+    os.makedirs(path, exist_ok=True)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    """Ponto de entrada do script para classificação de sentimentos."""
+    parser = argparse.ArgumentParser(
+        description="Classifica o sentimento das letras do Spotify com um LLM local"
+    )
+    parser.add_argument("dataset", help="Path to the spotify_millsongdata.csv dataset")
+    parser.add_argument("--model", default=DEFAULT_MODEL, help="Ollama model name to use")
+    parser.add_argument("--limit", type=int, default=None, help="Limit the number of songs to classify")
+    parser.add_argument("--output-dir", default="output", help="Directory where results are stored")
+    parser.add_argument("--mock", action="store_true", help="Use a simple keyword heuristic instead of calling the LLM")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    ensure_output_dir(args.output_dir)
+
+    classifier = SentimentClassifier(args.model, mock=args.mock)
+    counts: Dict[str, int] = {label: 0 for label in SUPPORTED_LABELS}
+    per_song_rows = []
+
+    for artist, song, lyrics in iter_lyrics(args.dataset, args.limit):
+        result = classifier.classify(lyrics)
+        counts[result.label] += 1
+        per_song_rows.append(
+            {
+                "artist": artist,
+                "song": song,
+                "label": result.label,
+                "latency_seconds": f"{result.latency:.4f}",
+            }
+        )
+
+    aggregated_path = os.path.join(args.output_dir, "sentiment_totals.json")
+    with open(aggregated_path, "w", encoding="utf-8") as fp:
+        json.dump(counts, fp, indent=2)
+
+    detailed_path = os.path.join(args.output_dir, "sentiment_details.csv")
+    with open(detailed_path, "w", newline="", encoding="utf-8") as fp:
+        writer = csv.DictWriter(fp, fieldnames=["artist", "song", "label", "latency_seconds"])
+        writer.writeheader()
+        writer.writerows(per_song_rows)
+
+    print("Sentiment summary:")
+    for label in SUPPORTED_LABELS:
+        print(f"  {label}: {counts[label]}")
+    print(f"Detailed results -> {detailed_path}")
+    print(f"Aggregated counts -> {aggregated_path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:  # pragma: no cover - top level error reporting
+        print(f"Error: {exc}", file=sys.stderr)
+        raise

--- a/scripts/split_csv_columns.py
+++ b/scripts/split_csv_columns.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""
+split_csv_columns.py
+Divide um arquivo CSV em N arquivos, um por coluna, nomeando cada arquivo com o título da coluna.
+
+Uso básico:
+    python split_csv_columns.py caminho/para/dados.csv
+
+Opções:
+    --output-dir DIR        Diretório de saída (padrão: <nome_arquivo>_columns)
+    --delimiter ";"         Delimitador (se não passar, tenta detectar automaticamente)
+    --encoding "utf-8-sig"  Codificação (padrão: utf-8-sig)
+    --no-header             Use se o CSV não tiver cabeçalho
+    --force                 Sobrescreve arquivos existentes
+    --quotechar "'"         Caractere de citação (padrão: ")
+"""
+
+from __future__ import annotations
+import argparse
+import csv
+import re
+from pathlib import Path
+
+
+def sanitize_filename(name: str, max_len: int = 80) -> str:
+    name = (name or "").replace("\n", " ").replace("\r", " ").strip()
+    name = re.sub(r"[^\w\-. ]+", "_", name, flags=re.UNICODE)  # troca chars problemáticos
+    name = re.sub(r"\s+", "_", name)                           # espaços -> _
+    return (name or "col")[:max_len]
+
+
+def detect_csv_params(
+    f,
+    sample_size: int = 65536,
+    explicit_delimiter: str | None = None,
+    quotechar: str = '"'
+) -> dict:
+    """Retorna kwargs para csv.reader/csv.writer (delimiter, quotechar, etc.)."""
+    if explicit_delimiter:
+        return dict(
+            delimiter=explicit_delimiter,
+            quotechar=quotechar,
+            doublequote=True,
+            skipinitialspace=False,
+            lineterminator="\n",
+            quoting=csv.QUOTE_MINIMAL,
+        )
+    pos = f.tell()
+    sample = f.read(sample_size)
+    f.seek(pos)
+    try:
+        sniffer = csv.Sniffer()
+        dialect = sniffer.sniff(sample)
+        return dict(
+            delimiter=dialect.delimiter,
+            quotechar=(quotechar or '"'),
+            doublequote=True,
+            skipinitialspace=dialect.skipinitialspace,
+            lineterminator="\n",
+            quoting=csv.QUOTE_MINIMAL,
+        )
+    except Exception:
+        return dict(
+            delimiter=",",
+            quotechar=(quotechar or '"'),
+            doublequote=True,
+            skipinitialspace=False,
+            lineterminator="\n",
+            quoting=csv.QUOTE_MINIMAL,
+        )
+
+
+def parse_args():
+    ap = argparse.ArgumentParser(
+        description="Divide um CSV em vários arquivos, um por coluna, usando o título como nome."
+    )
+    ap.add_argument("csv_path", help="Caminho do arquivo CSV de entrada")
+    ap.add_argument(
+        "--output-dir",
+        dest="output_dir",
+        default=None,
+        help="Diretório de saída",
+    )
+    ap.add_argument(
+        "--delimiter",
+        dest="delimiter",
+        default=None,
+        help="Delimitador do CSV (se omitido, detecta automaticamente)",
+    )
+    ap.add_argument(
+        "--quotechar",
+        dest="quotechar",
+        default='"',
+        help='Caractere de citação (padrão: ")',
+    )
+    ap.add_argument(
+        "--encoding",
+        dest="encoding",
+        default="utf-8-sig",
+        help="Codificação do arquivo (padrão: utf-8-sig)",
+    )
+    ap.add_argument(
+        "--no-header",
+        dest="no_header",
+        action="store_true",
+        help="Informe se o CSV NÃO possui cabeçalho",
+    )
+    ap.add_argument(
+        "--force",
+        dest="force",
+        action="store_true",
+        help="Sobrescrever arquivos existentes",
+    )
+    return ap.parse_args()
+
+
+def main():
+    args = parse_args()
+    in_path = Path(args.csv_path)
+    if not in_path.exists():
+        raise SystemExit(f"Erro: arquivo não encontrado: {in_path}")
+
+    base_out = (
+        Path(args.output_dir)
+        if args.output_dir
+        else in_path.with_suffix("").parent / f"{in_path.stem}_columns"
+    )
+    base_out.mkdir(parents=True, exist_ok=True)
+
+    with open(in_path, "r", encoding=args.encoding, newline="") as f:
+        fmt = detect_csv_params(
+            f, explicit_delimiter=args.delimiter, quotechar=args.quotechar
+        )
+        reader = csv.reader(f, **fmt)
+
+        try:
+            first_row = next(reader)
+        except StopIteration:
+            raise SystemExit("CSV vazio.")
+
+        if args.no_header:
+            headers = [f"col{i+1}" for i in range(len(first_row))]
+            first_data_row = first_row  # sem cabeçalho, já é dado
+        else:
+            headers = [
+                (h if h is not None and str(h).strip() else f"col{i+1}")
+                for i, h in enumerate(first_row)
+            ]
+            first_data_row = None
+
+        num_cols = len(headers)
+
+        # Gera nomes de arquivos baseados nos títulos (automático)
+        seen_names: set[str] = set()
+        filenames: list[str] = []
+        for i, h in enumerate(headers, start=1):
+            base_name = sanitize_filename(str(h))
+            name = base_name or f"col{i}"
+            # Evita colisões (títulos iguais): sufixa _2, _3, ...
+            candidate = f"{name}.csv"
+            k = 2
+            while (
+                candidate.lower() in seen_names
+                or (base_out / candidate).exists()
+                and not args.force
+            ):
+                candidate = f"{name}_{k}.csv"
+                k += 1
+            seen_names.add(candidate.lower())
+            filenames.append(candidate)
+
+        # Abre escritores
+        files = []
+        writers = []
+        try:
+            for i in range(num_cols):
+                out_path = base_out / filenames[i]
+                # Se existir e --force, sobrescreve; se não, já garantimos nome único acima
+                fh = open(out_path, "w", encoding=args.encoding, newline="")
+                writer = csv.writer(fh, **fmt)
+                if not args.no_header:
+                    writer.writerow([headers[i]])
+                files.append(fh)
+                writers.append(writer)
+
+            # Se não havia cabeçalho, grava a primeira linha de dados
+            if first_data_row is not None:
+                for i in range(num_cols):
+                    val = first_data_row[i] if i < len(first_data_row) else ""
+                    writers[i].writerow([val])
+
+            # Demais linhas
+            for row in reader:
+                for i in range(num_cols):
+                    val = row[i] if i < len(row) else ""
+                    writers[i].writerow([val])
+        finally:
+            for fh in files:
+                try:
+                    fh.close()
+                except Exception:
+                    pass
+
+    print(f"Concluído. {num_cols} arquivo(s) gerado(s) em: {base_out}")
+    for name in filenames:
+        print(f" - {base_out / name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/word_count_per_song.py
+++ b/scripts/word_count_per_song.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Ferramenta auxiliar para contagem de palavras por música.
+
+Este utilitário lê o dataset original do Spotify, tokeniza as letras mantendo
+apóstrofos (para conservar contrações) e, agora, distribui o processamento por
+threads para acelerar a contagem antes de registrar dois arquivos CSV:
+
+1. ``word_counts_global.csv`` – frequência total de cada palavra.
+2. ``word_counts_by_song.csv`` – frequência de cada palavra por artista e música.
+
+O processamento ocorre de forma independente do executável MPI para não
+interferir na coleta de métricas paralelas. Use quando precisar de uma visão
+serial e detalhada das letras.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import re
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Iterable
+
+TOKEN_REGEX = re.compile(r"[0-9A-Za-zÀ-ÖØ-öø-ÿ']+", re.UNICODE)
+
+
+def tokenize(text: str) -> Iterable[str]:
+    """Gera tokens com pelo menos 3 caracteres, preservando apóstrofos."""
+    for match in TOKEN_REGEX.finditer(text):
+        token = match.group().lower()
+        if len(token) < 3:
+            continue
+        # Evita registrar strings compostas apenas por apóstrofos
+        if not any(ch.isalnum() for ch in token):
+            continue
+        yield token
+
+
+def detect_delimiter(sample: str) -> str:
+    """Detecta o delimitador mais provável utilizando ``csv.Sniffer``."""
+    sniffer = csv.Sniffer()
+    try:
+        dialect = sniffer.sniff(sample)
+        return dialect.delimiter
+    except csv.Error:
+        return ","
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Conta palavras globalmente e por música de forma independente do MPI.",
+    )
+    parser.add_argument("csv_path", help="Caminho para o arquivo spotify_millsongdata.csv")
+    parser.add_argument(
+        "--output-dir",
+        default="output/serial_word_counts",
+        help="Diretório onde os resultados serão gravados (padrão: output/serial_word_counts)",
+    )
+    parser.add_argument(
+        "--encoding",
+        default="utf-8-sig",
+        help="Codificação do CSV de entrada (padrão: utf-8-sig)",
+    )
+    parser.add_argument(
+        "--delimiter",
+        default=None,
+        help="Delimitador do CSV (detectado automaticamente se omitido)",
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=0,
+        help=(
+            "Quantidade de threads de processamento (0 = auto, utiliza o número de CPUs "
+            "disponíveis)."
+        ),
+    )
+    return parser.parse_args()
+
+
+def resolve_workers(requested: int) -> int:
+    """Determina a quantidade efetiva de threads a serem utilizadas."""
+    if requested and requested > 0:
+        return requested
+    return max(1, os.cpu_count() or 1)
+
+
+def process_row(row: dict[str, str]) -> tuple[str, str, Counter[str]] | None:
+    """Tokeniza a letra e retorna o contador da música, se houver palavras."""
+    artist = row.get("artist", "").strip()
+    song = row.get("song", "").strip()
+    text = row.get("text", "")
+    word_counter: Counter[str] = Counter(tokenize(text))
+    if not word_counter:
+        return None
+    return artist, song, word_counter
+
+
+def main() -> None:
+    args = parse_args()
+    csv_path = Path(args.csv_path)
+    if not csv_path.exists():
+        raise SystemExit(f"Arquivo não encontrado: {csv_path}")
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    global_path = output_dir / "word_counts_global.csv"
+    per_song_path = output_dir / "word_counts_by_song.csv"
+
+    with open(csv_path, "r", encoding=args.encoding, newline="") as fh:
+        sample = fh.read(65536)
+        fh.seek(0)
+        delimiter = args.delimiter or detect_delimiter(sample)
+        reader = csv.DictReader(fh, delimiter=delimiter)
+        required_columns = {"artist", "song", "text"}
+        if not required_columns.issubset(reader.fieldnames or {}):
+            raise SystemExit(
+                "CSV sem colunas esperadas. Campos necessários: artist, song, text."
+            )
+
+        global_counter: Counter[str] = Counter()
+        total_rows = 0
+        workers = resolve_workers(args.workers)
+
+        with open(per_song_path, "w", encoding="utf-8", newline="") as per_song_fh:
+            per_song_writer = csv.writer(per_song_fh)
+            per_song_writer.writerow(["artist", "song", "word", "count"])
+
+            with ThreadPoolExecutor(max_workers=workers) as executor:
+                for result in executor.map(process_row, reader, chunksize=32):
+                    total_rows += 1
+                    if result is None:
+                        continue
+                    artist, song, word_counter = result
+                    for word, count in word_counter.items():
+                        global_counter[word] += count
+                        per_song_writer.writerow([artist, song, word, count])
+
+    with open(global_path, "w", encoding="utf-8", newline="") as global_fh:
+        writer = csv.writer(global_fh)
+        writer.writerow(["word", "count"])
+        for word, count in global_counter.most_common():
+            writer.writerow([word, count])
+
+    print(
+        "Concluído. Processadas",
+        total_rows,
+        "linhas. Arquivos gerados em",
+        os.fspath(output_dir),
+    )
+    print(" -", os.fspath(global_path))
+    print(" -", os.fspath(per_song_path))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/parallel_spotify.c
+++ b/src/parallel_spotify.c
@@ -1,0 +1,1113 @@
+/*
+ * Aplicação principal em MPI para análise do dataset Spotify Million Song.
+ *
+ * O programa divide o arquivo CSV entre todos os processos e realiza três
+ * tarefas principais de forma paralela: contagem de palavras nas letras,
+ * contagem de músicas por artista e consolidação de métricas de tempo. O
+ * processo de rank mestre agrega os resultados parciais, gera arquivos de
+ * saída e salva medições de desempenho para posterior análise.
+ *
+ * A documentação está escrita em português para facilitar a consulta pelos
+ * avaliadores do trabalho.
+ */
+#define _GNU_SOURCE
+#include <mpi.h>
+#include <ctype.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <limits.h>
+
+#ifdef _WIN32
+#include <direct.h>
+#define MKDIR(path) _mkdir(path)
+#else
+#include <unistd.h>
+#define MKDIR(path) mkdir(path, 0777)
+#endif
+
+#define DEFAULT_WORD_LIMIT 0
+#define DEFAULT_ARTIST_LIMIT 0
+
+typedef long long CountType;
+
+/* Estrutura chave-valor usada para armazenar entradas de tabelas de hash. */
+typedef struct {
+    char *key;
+    CountType value;
+} Entry;
+
+/*
+ * Implementação simples de tabela de hash com endereçamento aberto, usada
+ * tanto para a contagem de palavras quanto para a contagem de artistas.
+ */
+typedef struct {
+    Entry *entries;
+    size_t capacity;
+    size_t size;
+} HashTable;
+
+/* Retorna a próxima potência de dois maior ou igual ao valor solicitado. */
+static size_t next_power_of_two(size_t value) {
+    size_t power = 1;
+    while (power < value) {
+        power <<= 1U;
+    }
+    return power < 8 ? 8 : power;
+}
+
+/* Calcula o hash FNV-1a para strings, garantindo boa distribuição. */
+static uint64_t hash_string(const char *str) {
+    const uint64_t fnv_prime = 1099511628211ULL;
+    uint64_t hash = 1469598103934665603ULL;
+    for (const unsigned char *p = (const unsigned char *)str; *p; ++p) {
+        hash ^= (uint64_t)(*p);
+        hash *= fnv_prime;
+    }
+    return hash;
+}
+
+/* Inicializa a tabela de hash com a capacidade solicitada. */
+static void ht_init(HashTable *ht, size_t initial_capacity) {
+    ht->capacity = next_power_of_two(initial_capacity);
+    ht->size = 0;
+    ht->entries = (Entry *)calloc(ht->capacity, sizeof(Entry));
+    if (!ht->entries) {
+        fprintf(stderr, "Failed to allocate hash table with capacity %zu\n", ht->capacity);
+        MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+    }
+}
+
+/* Libera os recursos associados à tabela de hash. */
+static void ht_free(HashTable *ht) {
+    if (!ht || !ht->entries) {
+        return;
+    }
+    for (size_t i = 0; i < ht->capacity; ++i) {
+        if (ht->entries[i].key) {
+            free(ht->entries[i].key);
+        }
+    }
+    free(ht->entries);
+    ht->entries = NULL;
+    ht->capacity = 0;
+    ht->size = 0;
+}
+
+/* Duplica a tabela de hash quando o fator de carga fica elevado. */
+static void ht_resize(HashTable *ht, size_t new_capacity) {
+    HashTable resized;
+    ht_init(&resized, new_capacity);
+    for (size_t i = 0; i < ht->capacity; ++i) {
+        if (ht->entries[i].key) {
+            Entry *entry = &ht->entries[i];
+            const size_t mask = resized.capacity - 1U;
+            size_t index = hash_string(entry->key) & mask;
+            while (resized.entries[index].key) {
+                index = (index + 1U) & mask;
+            }
+            resized.entries[index].key = strdup(entry->key);
+            if (!resized.entries[index].key) {
+                fprintf(stderr, "Failed to duplicate key during resize\n");
+                MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+            }
+            resized.entries[index].value = entry->value;
+            resized.size++;
+        }
+    }
+    ht_free(ht);
+    *ht = resized;
+}
+
+/* Insere ou atualiza uma chave na tabela de hash. */
+static void ht_put(HashTable *ht, const char *key, CountType delta) {
+    if (delta == 0) {
+        return;
+    }
+    if ((double)ht->size / (double)ht->capacity > 0.7) {
+        ht_resize(ht, ht->capacity << 1U);
+    }
+    const size_t mask = ht->capacity - 1U;
+    size_t index = hash_string(key) & mask;
+    while (ht->entries[index].key) {
+        if (strcmp(ht->entries[index].key, key) == 0) {
+            ht->entries[index].value += delta;
+            return;
+        }
+        index = (index + 1U) & mask;
+    }
+    ht->entries[index].key = strdup(key);
+    if (!ht->entries[index].key) {
+        fprintf(stderr, "Failed to duplicate key '%s'\n", key);
+        MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+    }
+    ht->entries[index].value = delta;
+    ht->size++;
+}
+
+/* Mescla todas as entradas de uma tabela de hash em outra. */
+static void ht_merge(HashTable *dest, const HashTable *src) {
+    for (size_t i = 0; i < src->capacity; ++i) {
+        if (src->entries[i].key) {
+            ht_put(dest, src->entries[i].key, src->entries[i].value);
+        }
+    }
+}
+
+/* Converte o conteúdo da tabela para um vetor denso de entradas. */
+static Entry *ht_to_array(const HashTable *ht, size_t *out_size) {
+    Entry *array = (Entry *)malloc(sizeof(Entry) * ht->size);
+    if (!array) {
+        fprintf(stderr, "Failed to allocate array for hash table export\n");
+        MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+    }
+    size_t idx = 0;
+    for (size_t i = 0; i < ht->capacity; ++i) {
+        if (ht->entries[i].key) {
+            array[idx++] = ht->entries[i];
+        }
+    }
+    *out_size = idx;
+    return array;
+}
+
+/* Função de ordenação: valores maiores primeiro e, em empate, ordem alfabética. */
+static int entry_compare_desc(const void *a, const void *b) {
+    const Entry *ea = (const Entry *)a;
+    const Entry *eb = (const Entry *)b;
+    if (ea->value < eb->value) {
+        return 1;
+    }
+    if (ea->value > eb->value) {
+        return -1;
+    }
+    return strcmp(ea->key, eb->key);
+}
+
+/* Remove espaços em branco no início e fim da string modificando-a in place. */
+static void trim_inplace(char *value) {
+    if (!value) {
+        return;
+    }
+    size_t len = strlen(value);
+    size_t start = 0;
+    while (start < len && isspace((unsigned char)value[start])) {
+        start++;
+    }
+    size_t end = len;
+    while (end > start && isspace((unsigned char)value[end - 1])) {
+        end--;
+    }
+    if (start > 0) {
+        memmove(value, value + start, end - start);
+    }
+    value[end - start] = '\0';
+}
+
+/*
+ * Duplica um campo CSV removendo espaços excedentes e, opcionalmente,
+ * preservando as aspas externas exatamente como no arquivo original. O
+ * chamador é responsável por liberar o ponteiro retornado.
+ */
+static char *duplicate_field(const char *field, int preserve_outer_quotes) {
+    size_t len = strlen(field);
+    size_t start = 0;
+    size_t end = len;
+    while (start < len && isspace((unsigned char)field[start])) {
+        start++;
+    }
+    while (end > start && isspace((unsigned char)field[end - 1])) {
+        end--;
+    }
+    int quoted = (end > start + 1 && field[start] == '"' && field[end - 1] == '"');
+    char *result = (char *)malloc(end - start + 1);
+    if (!result) {
+        fprintf(stderr, "Failed to allocate memory for CSV field\n");
+        MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+    }
+    size_t j = 0;
+    if (preserve_outer_quotes && quoted) {
+        for (size_t i = start; i < end; ++i) {
+            result[j++] = field[i];
+        }
+    } else {
+        size_t inner_start = start;
+        size_t inner_end = end;
+        if (quoted) {
+            inner_start++;
+            inner_end--;
+        }
+        for (size_t i = inner_start; i < inner_end; ++i) {
+            if (field[i] == '"' && i + 1 < inner_end && field[i + 1] == '"') {
+                result[j++] = '"';
+                i++;
+            } else {
+                result[j++] = field[i];
+            }
+        }
+    }
+    result[j] = '\0';
+    trim_inplace(result);
+    return result;
+}
+
+/* Extrai artista e letra a partir de uma linha CSV, respeitando as aspas originais. */
+static int parse_csv_line(const char *line, char **artist_out, char **lyrics_out,
+                          int preserve_artist_quotes, int preserve_lyrics_quotes) {
+    if (!line || !artist_out || !lyrics_out) {
+        return 0;
+    }
+    char *buffer = strdup(line);
+    if (!buffer) {
+        return 0;
+    }
+    size_t len = strlen(buffer);
+    while (len > 0 && (buffer[len - 1] == '\n' || buffer[len - 1] == '\r')) {
+        buffer[--len] = '\0';
+    }
+    char *fields[4] = {0};
+    int field_index = 0;
+    int in_quotes = 0;
+    char *ptr = buffer;
+    char *token_start = buffer;
+    while (*ptr) {
+        if (*ptr == '"') {
+            if (in_quotes && ptr[1] == '"') {
+                ptr++;
+            } else {
+                in_quotes = !in_quotes;
+            }
+        } else if (*ptr == ',' && !in_quotes) {
+            *ptr = '\0';
+            if (field_index < 4) {
+                fields[field_index++] = token_start;
+            }
+            token_start = ptr + 1;
+            if (field_index == 3) {
+                break;
+            }
+        }
+        ptr++;
+    }
+    if (field_index < 3) {
+        free(buffer);
+        return 0;
+    }
+    fields[3] = token_start;
+    *artist_out = duplicate_field(fields[0], preserve_artist_quotes);
+    *lyrics_out = duplicate_field(fields[3], preserve_lyrics_quotes);
+    free(buffer);
+    return *artist_out && *lyrics_out;
+}
+
+/* Escreve uma linha CSV escapando aspas para o campo textual. */
+static void write_csv_entry(FILE *fp, const char *key, CountType value) {
+    fputc('"', fp);
+    for (const char *p = key; *p; ++p) {
+        if (*p == '"') {
+            fputc('"', fp);
+            fputc('"', fp);
+        } else {
+            fputc(*p, fp);
+        }
+    }
+    fputc('"', fp);
+    fprintf(fp, ",%lld\n", value);
+}
+
+/*
+ * Exporta os resultados agregados para um arquivo CSV, ordenando os itens
+ * pelos maiores valores e respeitando o limite solicitado.
+ */
+static void write_table_csv(const HashTable *ht, const char *filepath, const char *key_header, int limit) {
+    FILE *fp = fopen(filepath, "w");
+    if (!fp) {
+        fprintf(stderr, "Failed to open output file %s: %s\n", filepath, strerror(errno));
+        return;
+    }
+    fprintf(fp, "%s,count\n", key_header);
+    size_t array_size = 0;
+    Entry *entries = ht_to_array(ht, &array_size);
+    qsort(entries, array_size, sizeof(Entry), entry_compare_desc);
+    size_t max_items = array_size;
+    if (limit > 0 && (size_t)limit < array_size) {
+        max_items = (size_t)limit;
+    }
+    for (size_t i = 0; i < max_items; ++i) {
+        write_csv_entry(fp, entries[i].key, entries[i].value);
+    }
+    free(entries);
+    fclose(fp);
+}
+
+/*
+ * Tokeniza as letras, acumula contagem por palavra e atualiza o total geral,
+ * preservando apóstrofos para não descaracterizar contrações e variações.
+ */
+static void process_lyrics(HashTable *word_counts, const char *lyrics, CountType *total_words) {
+    size_t capacity = 64;
+    char *buffer = (char *)malloc(capacity);
+    if (!buffer) {
+        fprintf(stderr, "Failed to allocate buffer for tokenisation\n");
+        MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+    }
+    size_t length = 0;
+    for (const unsigned char *p = (const unsigned char *)lyrics; *p; ++p) {
+        if (isalnum(*p) || *p == '\'') {
+            if (length + 1 >= capacity) {
+                capacity *= 2U;
+                char *tmp = (char *)realloc(buffer, capacity);
+                if (!tmp) {
+                    free(buffer);
+                    fprintf(stderr, "Failed to grow token buffer\n");
+                    MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+                }
+                buffer = tmp;
+            }
+            if (isalnum(*p)) {
+                buffer[length++] = (char)tolower(*p);
+            } else {
+                buffer[length++] = (char)*p;
+            }
+        } else {
+            if (length > 0) {
+                buffer[length] = '\0';
+                if (length >= 3) {
+                    ht_put(word_counts, buffer, 1);
+                    (*total_words)++;
+                }
+                length = 0;
+            }
+        }
+    }
+    if (length > 0) {
+        buffer[length] = '\0';
+        if (length >= 3) {
+            ht_put(word_counts, buffer, 1);
+            (*total_words)++;
+        }
+    }
+    free(buffer);
+}
+
+/* Envia todas as entradas de uma tabela de hash para outro processo MPI. */
+static void send_hash_table(const HashTable *ht, int dest, int tag_base, MPI_Comm comm) {
+    int entry_count = (int)ht->size;
+    MPI_Send(&entry_count, 1, MPI_INT, dest, tag_base, comm);
+    for (size_t i = 0; i < ht->capacity; ++i) {
+        if (!ht->entries[i].key) {
+            continue;
+        }
+        int len = (int)strlen(ht->entries[i].key);
+        CountType value = ht->entries[i].value;
+        MPI_Send(&len, 1, MPI_INT, dest, tag_base + 1, comm);
+        MPI_Send(ht->entries[i].key, len, MPI_CHAR, dest, tag_base + 2, comm);
+        MPI_Send(&value, 1, MPI_LONG_LONG, dest, tag_base + 3, comm);
+    }
+}
+
+/* Recebe uma tabela de hash serializada e mescla os valores no destino. */
+static void receive_hash_table(HashTable *dest, int source, int tag_base, MPI_Comm comm) {
+    MPI_Status status;
+    int entry_count = 0;
+    MPI_Recv(&entry_count, 1, MPI_INT, source, tag_base, comm, &status);
+    for (int i = 0; i < entry_count; ++i) {
+        int len = 0;
+        MPI_Recv(&len, 1, MPI_INT, source, tag_base + 1, comm, &status);
+        char *buffer = (char *)malloc(len + 1);
+        if (!buffer) {
+            fprintf(stderr, "Failed to allocate buffer for received key\n");
+            MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+        }
+        MPI_Recv(buffer, len, MPI_CHAR, source, tag_base + 2, comm, &status);
+        buffer[len] = '\0';
+        CountType value = 0;
+        MPI_Recv(&value, 1, MPI_LONG_LONG, source, tag_base + 3, comm, &status);
+        ht_put(dest, buffer, value);
+        free(buffer);
+    }
+}
+
+/* Obtém o tamanho do arquivo de entrada em bytes. */
+static long long get_file_size(const char *path) {
+    struct stat st;
+    if (stat(path, &st) != 0) {
+        return -1;
+    }
+    return (long long)st.st_size;
+}
+
+/* Mede o comprimento da linha de cabeçalho para permitir o fatiamento do CSV. */
+static long long compute_header_length(const char *path) {
+    FILE *fp = fopen(path, "r");
+    if (!fp) {
+        return -1;
+    }
+    char *line = NULL;
+    size_t n = 0;
+    ssize_t read = getline(&line, &n, fp);
+    long long header_len = -1;
+    if (read >= 0) {
+        header_len = (long long)ftell(fp);
+    }
+    free(line);
+    fclose(fp);
+    return header_len;
+}
+
+/* Cria o diretório de saída caso ele não exista. */
+static void ensure_output_dir(const char *path) {
+    struct stat st;
+    if (stat(path, &st) == 0) {
+        return;
+    }
+    if (MKDIR(path) != 0 && errno != EEXIST) {
+        fprintf(stderr, "Failed to create directory %s: %s\n", path, strerror(errno));
+    }
+}
+
+/*
+ * Cria diretórios recursivamente, garantindo que todos os níveis do caminho
+ * existam antes do uso. Retorna 0 em sucesso e -1 em caso de erro.
+ */
+static int ensure_directory_recursive(const char *path) {
+    if (!path || !*path) {
+        return 0;
+    }
+    size_t len = strlen(path);
+    if (len >= PATH_MAX) {
+        errno = ENAMETOOLONG;
+        return -1;
+    }
+    char buffer[PATH_MAX];
+    memcpy(buffer, path, len + 1);
+    for (size_t i = 1; i < len; ++i) {
+        if (buffer[i] == '/' || buffer[i] == '\\') {
+            char saved = buffer[i];
+            buffer[i] = '\0';
+            if (buffer[0] != '\0' && strcmp(buffer, ".") != 0) {
+                if (MKDIR(buffer) != 0 && errno != EEXIST) {
+                    buffer[i] = saved;
+                    return -1;
+                }
+            }
+            buffer[i] = saved;
+        }
+    }
+    if (MKDIR(buffer) != 0 && errno != EEXIST) {
+        return -1;
+    }
+    return 0;
+}
+
+/*
+ * Normaliza o nome do cabeçalho para servir como base de nome de arquivo,
+ * substituindo caracteres problemáticos por sublinhados.
+ */
+static void sanitize_header_name(const char *input, char *output, size_t output_len) {
+    if (!output || output_len == 0) {
+        return;
+    }
+    size_t j = 0;
+    if (input) {
+        for (size_t i = 0; input[i] != '\0'; ++i) {
+            unsigned char c = (unsigned char)input[i];
+            if (c == '\n' || c == '\r') {
+                continue;
+            }
+            if (isspace(c)) {
+                if (j + 1 < output_len) {
+                    output[j++] = '_';
+                }
+            } else if (isalnum(c) || c == '-' || c == '.' || c == '_') {
+                if (j + 1 < output_len) {
+                    output[j++] = (char)c;
+                }
+            } else {
+                if (j + 1 < output_len) {
+                    output[j++] = '_';
+                }
+            }
+        }
+    }
+    if (j == 0) {
+        const char *fallback = "col";
+        for (size_t i = 0; fallback[i] != '\0' && j + 1 < output_len; ++i) {
+            output[j++] = fallback[i];
+        }
+    }
+    output[j] = '\0';
+}
+
+/*
+ * Lê um registro completo do CSV, respeitando quebras de linha dentro de
+ * campos entre aspas. Retorna o total de bytes lidos ou -1 no fim do arquivo.
+ */
+static ssize_t read_csv_record(FILE *fp, char **buffer, size_t *buf_size) {
+    if (!fp) {
+        return -1;
+    }
+    if (!buffer || !buf_size) {
+        return -1;
+    }
+    if (!*buffer || *buf_size == 0) {
+        *buf_size = 1024;
+        *buffer = (char *)malloc(*buf_size);
+        if (!*buffer) {
+            fprintf(stderr, "Failed to allocate CSV buffer\n");
+            return -1;
+        }
+    }
+    size_t pos = 0;
+    int in_quotes = 0;
+    while (1) {
+        int ch = fgetc(fp);
+        if (ch == EOF) {
+            if (pos == 0) {
+                return -1;
+            }
+            break;
+        }
+        if (pos + 2 >= *buf_size) {
+            size_t new_size = *buf_size * 2U;
+            char *tmp = (char *)realloc(*buffer, new_size);
+            if (!tmp) {
+                fprintf(stderr, "Failed to grow CSV buffer\n");
+                return -1;
+            }
+            *buffer = tmp;
+            *buf_size = new_size;
+        }
+        (*buffer)[pos++] = (char)ch;
+        if (ch == '"') {
+            if (!in_quotes) {
+                in_quotes = 1;
+            } else {
+                int next = fgetc(fp);
+                if (next == '"') {
+                    if (pos + 1 >= *buf_size) {
+                        size_t new_size = *buf_size * 2U;
+                        char *tmp = (char *)realloc(*buffer, new_size);
+                        if (!tmp) {
+                            fprintf(stderr, "Failed to grow CSV buffer\n");
+                            return -1;
+                        }
+                        *buffer = tmp;
+                        *buf_size = new_size;
+                    }
+                    (*buffer)[pos++] = '"';
+                } else {
+                    if (next != EOF) {
+                        ungetc(next, fp);
+                    }
+                    in_quotes = 0;
+                }
+            }
+        } else if ((ch == '\n' || ch == '\r') && !in_quotes) {
+            if (ch == '\r') {
+                int next = fgetc(fp);
+                if (next == '\n') {
+                    if (pos + 1 >= *buf_size) {
+                        size_t new_size = *buf_size * 2U;
+                        char *tmp = (char *)realloc(*buffer, new_size);
+                        if (!tmp) {
+                            fprintf(stderr, "Failed to grow CSV buffer\n");
+                            return -1;
+                        }
+                        *buffer = tmp;
+                        *buf_size = new_size;
+                    }
+                    (*buffer)[pos++] = (char)next;
+                } else if (next != EOF) {
+                    ungetc(next, fp);
+                }
+            }
+            break;
+        }
+    }
+    (*buffer)[pos] = '\0';
+    return (ssize_t)pos;
+}
+
+/*
+ * Cria arquivos separados para as colunas de artistas e letras, mantendo as
+ * aspas originais dos campos de texto. Retorna 1 em sucesso e 0 em caso de
+ * falha.
+ */
+static int split_dataset_columns(const char *dataset_path, const char *split_dir,
+                                 const char *artist_base_name, const char *text_base_name,
+                                 const char *artist_header_label, const char *text_header_label,
+                                 char *artist_out_path, size_t artist_out_len,
+                                 char *text_out_path, size_t text_out_len) {
+    if (!dataset_path || !split_dir || !artist_base_name || !text_base_name) {
+        return 0;
+    }
+    if (!artist_out_path || !text_out_path) {
+        return 0;
+    }
+    if (ensure_directory_recursive(split_dir) != 0) {
+        fprintf(stderr, "Failed to create split directory %s: %s\n", split_dir, strerror(errno));
+        return 0;
+    }
+    int needed = snprintf(artist_out_path, artist_out_len, "%s/%s.csv", split_dir, artist_base_name);
+    if (needed < 0 || (size_t)needed >= artist_out_len) {
+        fprintf(stderr, "Artist split path is too long\n");
+        return 0;
+    }
+    needed = snprintf(text_out_path, text_out_len, "%s/%s.csv", split_dir, text_base_name);
+    if (needed < 0 || (size_t)needed >= text_out_len) {
+        fprintf(stderr, "Text split path is too long\n");
+        return 0;
+    }
+
+    FILE *input = fopen(dataset_path, "r");
+    if (!input) {
+        fprintf(stderr, "Failed to open dataset %s for splitting\n", dataset_path);
+        return 0;
+    }
+    FILE *artist_fp = fopen(artist_out_path, "w");
+    FILE *text_fp = fopen(text_out_path, "w");
+    if (!artist_fp || !text_fp) {
+        fprintf(stderr, "Failed to create split files in %s\n", split_dir);
+        if (artist_fp) {
+            fclose(artist_fp);
+        }
+        if (text_fp) {
+            fclose(text_fp);
+        }
+        fclose(input);
+        return 0;
+    }
+
+    fprintf(artist_fp, "%s\n", (artist_header_label && *artist_header_label) ? artist_header_label : "Artists");
+    fprintf(text_fp, "%s\n", (text_header_label && *text_header_label) ? text_header_label : "Texts");
+
+    char *line = NULL;
+    size_t line_cap = 0;
+    ssize_t read = read_csv_record(input, &line, &line_cap); /* descarta cabeçalho */
+    if (read < 0) {
+        free(line);
+        fclose(artist_fp);
+        fclose(text_fp);
+        fclose(input);
+        return 1; /* dataset vazio, apenas cabeçalhos criados */
+    }
+
+    while ((read = read_csv_record(input, &line, &line_cap)) >= 0) {
+        if (read == 0) {
+            continue;
+        }
+        char *artist_raw = NULL;
+        char *lyrics_raw = NULL;
+        if (!parse_csv_line(line, &artist_raw, &lyrics_raw, 1, 1)) {
+            free(artist_raw);
+            free(lyrics_raw);
+            continue;
+        }
+        fprintf(artist_fp, "%s\n", artist_raw ? artist_raw : "");
+        fprintf(text_fp, "%s\n", lyrics_raw ? lyrics_raw : "");
+        free(artist_raw);
+        free(lyrics_raw);
+    }
+
+    free(line);
+    fclose(artist_fp);
+    fclose(text_fp);
+    fclose(input);
+    return 1;
+}
+
+/* Função principal que distribui o trabalho entre os processos MPI. */
+int main(int argc, char **argv) {
+    MPI_Init(&argc, &argv);
+
+    int rank = 0;
+    int world_size = 0;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &world_size);
+
+    if (argc < 2) {
+        if (rank == 0) {
+            fprintf(stderr, "Usage: mpirun -np <n> %s <dataset.csv> [--word-limit N] [--artist-limit N] [--output-dir DIR]\n", argv[0]);
+        }
+        MPI_Finalize();
+        return EXIT_FAILURE;
+    }
+
+    const char *dataset_path = argv[1];
+    int word_limit = DEFAULT_WORD_LIMIT;
+    int artist_limit = DEFAULT_ARTIST_LIMIT;
+    char output_dir[PATH_MAX];
+    snprintf(output_dir, sizeof(output_dir), "output");
+    char word_output_path[PATH_MAX] = {0};
+    char artist_output_path[PATH_MAX] = {0};
+    char metrics_output_path[PATH_MAX] = {0};
+    char split_dir[PATH_MAX] = {0};
+    char sanitized_artist[128] = {0};
+    char sanitized_text[128] = {0};
+    char artist_header_label[128] = {0};
+    char text_header_label[128] = {0};
+    char artist_split_path[PATH_MAX] = {0};
+    char text_split_path[PATH_MAX] = {0};
+
+    for (int i = 2; i < argc; ++i) {
+        if (strcmp(argv[i], "--word-limit") == 0 && i + 1 < argc) {
+            word_limit = atoi(argv[++i]);
+        } else if (strcmp(argv[i], "--artist-limit") == 0 && i + 1 < argc) {
+            artist_limit = atoi(argv[++i]);
+        } else if (strcmp(argv[i], "--output-dir") == 0 && i + 1 < argc) {
+            strncpy(output_dir, argv[++i], sizeof(output_dir) - 1);
+            output_dir[sizeof(output_dir) - 1] = '\0';
+        } else if (rank == 0) {
+            fprintf(stderr, "Ignoring unknown argument: %s\n", argv[i]);
+        }
+    }
+
+    int split_dir_len = snprintf(split_dir, sizeof(split_dir), "%s/split_columns", output_dir);
+    if (split_dir_len < 0 || (size_t)split_dir_len >= sizeof(split_dir)) {
+        if (rank == 0) {
+            fprintf(stderr, "Split directory path is too long\n");
+        }
+        MPI_Finalize();
+        return EXIT_FAILURE;
+    }
+
+    if (rank == 0) {
+        if (ensure_directory_recursive(output_dir) != 0) {
+            fprintf(stderr, "Failed to prepare output directory %s: %s\n", output_dir, strerror(errno));
+            MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+        }
+        if (ensure_directory_recursive(split_dir) != 0) {
+            fprintf(stderr, "Failed to prepare split directory %s: %s\n", split_dir, strerror(errno));
+            MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+        }
+
+        FILE *header_fp = fopen(dataset_path, "r");
+        if (!header_fp) {
+            fprintf(stderr, "Failed to open dataset %s\n", dataset_path);
+            MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+        }
+        char *header_line = NULL;
+        size_t header_cap = 0;
+        ssize_t header_read = read_csv_record(header_fp, &header_line, &header_cap);
+        if (header_read < 0) {
+            fprintf(stderr, "Dataset does not contain a header row\n");
+            free(header_line);
+            fclose(header_fp);
+            MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+        }
+        char *artist_header_tmp = NULL;
+        char *text_header_tmp = NULL;
+        if (!parse_csv_line(header_line, &artist_header_tmp, &text_header_tmp, 0, 0)) {
+            fprintf(stderr, "Unable to parse dataset header\n");
+            free(header_line);
+            fclose(header_fp);
+            MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+        }
+        strncpy(artist_header_label, artist_header_tmp, sizeof(artist_header_label) - 1);
+        strncpy(text_header_label, text_header_tmp, sizeof(text_header_label) - 1);
+        artist_header_label[sizeof(artist_header_label) - 1] = '\0';
+        text_header_label[sizeof(text_header_label) - 1] = '\0';
+        sanitize_header_name(artist_header_tmp, sanitized_artist, sizeof(sanitized_artist));
+        sanitize_header_name(text_header_tmp, sanitized_text, sizeof(sanitized_text));
+        free(artist_header_tmp);
+        free(text_header_tmp);
+        free(header_line);
+        fclose(header_fp);
+
+        if (!split_dataset_columns(dataset_path, split_dir, sanitized_artist, sanitized_text,
+                                   artist_header_label, text_header_label,
+                                   artist_split_path, sizeof(artist_split_path),
+                                   text_split_path, sizeof(text_split_path))) {
+            fprintf(stderr, "Failed to split dataset columns\n");
+            MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+        }
+    }
+
+    MPI_Bcast(sanitized_artist, (int)sizeof(sanitized_artist), MPI_CHAR, 0, MPI_COMM_WORLD);
+    MPI_Bcast(sanitized_text, (int)sizeof(sanitized_text), MPI_CHAR, 0, MPI_COMM_WORLD);
+
+    int artist_path_len = snprintf(artist_split_path, sizeof(artist_split_path), "%s/%s.csv", split_dir, sanitized_artist);
+    if (artist_path_len < 0 || (size_t)artist_path_len >= sizeof(artist_split_path)) {
+        if (rank == 0) {
+            fprintf(stderr, "Artist split path is too long\n");
+        }
+        MPI_Finalize();
+        return EXIT_FAILURE;
+    }
+    int text_path_len = snprintf(text_split_path, sizeof(text_split_path), "%s/%s.csv", split_dir, sanitized_text);
+    if (text_path_len < 0 || (size_t)text_path_len >= sizeof(text_split_path)) {
+        if (rank == 0) {
+            fprintf(stderr, "Text split path is too long\n");
+        }
+        MPI_Finalize();
+        return EXIT_FAILURE;
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    double start_time = MPI_Wtime();
+
+    long long text_header_len = compute_header_length(text_split_path);
+    long long text_file_size = get_file_size(text_split_path);
+    if (text_header_len < 0 || text_file_size < 0) {
+        fprintf(stderr, "Rank %d failed to obtain text column metadata\n", rank);
+        MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+    }
+    long long artist_header_len = compute_header_length(artist_split_path);
+    long long artist_file_size = get_file_size(artist_split_path);
+    if (artist_header_len < 0 || artist_file_size < 0) {
+        fprintf(stderr, "Rank %d failed to obtain artist column metadata\n", rank);
+        MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+    }
+
+    long long text_data_bytes = text_file_size > text_header_len ? text_file_size - text_header_len : 0;
+    long long text_base_chunk = text_data_bytes / world_size;
+    long long text_remainder = text_data_bytes % world_size;
+    long long text_local_start = text_header_len + rank * text_base_chunk + (rank < text_remainder ? rank : text_remainder);
+    long long text_local_end = text_local_start + text_base_chunk + (rank < text_remainder ? 1 : 0);
+    if (rank == world_size - 1) {
+        text_local_end = text_file_size;
+    }
+
+    long long artist_data_bytes = artist_file_size > artist_header_len ? artist_file_size - artist_header_len : 0;
+    long long artist_base_chunk = artist_data_bytes / world_size;
+    long long artist_remainder = artist_data_bytes % world_size;
+    long long artist_local_start = artist_header_len + rank * artist_base_chunk + (rank < artist_remainder ? rank : artist_remainder);
+    long long artist_local_end = artist_local_start + artist_base_chunk + (rank < artist_remainder ? 1 : 0);
+    if (rank == world_size - 1) {
+        artist_local_end = artist_file_size;
+    }
+
+    HashTable word_counts;
+    HashTable artist_counts;
+    ht_init(&word_counts, 65536);
+    ht_init(&artist_counts, 8192);
+
+    CountType local_word_total = 0;
+    CountType local_song_total = 0;
+
+    char *line = NULL;
+    size_t line_buf = 0;
+
+    FILE *text_fp = fopen(text_split_path, "r");
+    if (!text_fp) {
+        fprintf(stderr, "Rank %d failed to open text column %s\n", rank, text_split_path);
+        MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+    }
+
+    if (text_local_start > text_header_len) {
+        if (fseeko(text_fp, text_local_start, SEEK_SET) != 0) {
+            fprintf(stderr, "Rank %d failed to seek text column offset %lld\n", rank, text_local_start);
+            MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+        }
+        if (text_local_start > text_header_len) {
+            if (read_csv_record(text_fp, &line, &line_buf) < 0) {
+                /* offset apontou além do fim */
+            }
+        }
+    } else {
+        if (fseeko(text_fp, text_header_len, SEEK_SET) != 0) {
+            fprintf(stderr, "Rank %d failed to seek to text header end\n", rank);
+            MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+        }
+    }
+
+    while (1) {
+        long long position = ftello(text_fp);
+        if (position < 0) {
+            break;
+        }
+        if (rank != world_size - 1 && position >= text_local_end) {
+            break;
+        }
+        ssize_t read_len = read_csv_record(text_fp, &line, &line_buf);
+        if (read_len < 0) {
+            break;
+        }
+        if (read_len == 0) {
+            continue;
+        }
+        while (read_len > 0 && (line[read_len - 1] == '\n' || line[read_len - 1] == '\r')) {
+            line[--read_len] = '\0';
+        }
+        char *lyrics = duplicate_field(line, 1);
+        if (lyrics && *lyrics) {
+            process_lyrics(&word_counts, lyrics, &local_word_total);
+        }
+        free(lyrics);
+    }
+    free(line);
+    fclose(text_fp);
+
+    line = NULL;
+    line_buf = 0;
+
+    FILE *artist_fp = fopen(artist_split_path, "r");
+    if (!artist_fp) {
+        fprintf(stderr, "Rank %d failed to open artist column %s\n", rank, artist_split_path);
+        MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+    }
+
+    if (artist_local_start > artist_header_len) {
+        if (fseeko(artist_fp, artist_local_start, SEEK_SET) != 0) {
+            fprintf(stderr, "Rank %d failed to seek artist column offset %lld\n", rank, artist_local_start);
+            MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+        }
+        if (artist_local_start > artist_header_len) {
+            if (read_csv_record(artist_fp, &line, &line_buf) < 0) {
+                /* offset apontou além do fim */
+            }
+        }
+    } else {
+        if (fseeko(artist_fp, artist_header_len, SEEK_SET) != 0) {
+            fprintf(stderr, "Rank %d failed to seek to artist header end\n", rank);
+            MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+        }
+    }
+
+    while (1) {
+        long long position = ftello(artist_fp);
+        if (position < 0) {
+            break;
+        }
+        if (rank != world_size - 1 && position >= artist_local_end) {
+            break;
+        }
+        ssize_t read_len = read_csv_record(artist_fp, &line, &line_buf);
+        if (read_len < 0) {
+            break;
+        }
+        if (read_len == 0) {
+            continue;
+        }
+        while (read_len > 0 && (line[read_len - 1] == '\n' || line[read_len - 1] == '\r')) {
+            line[--read_len] = '\0';
+        }
+        char *artist = duplicate_field(line, 0);
+        if (artist && *artist) {
+            ht_put(&artist_counts, artist, 1);
+        }
+        local_song_total++;
+        free(artist);
+    }
+
+    free(line);
+    fclose(artist_fp);
+
+    double compute_time = MPI_Wtime() - start_time;
+
+    CountType global_word_total = 0;
+    CountType global_song_total = 0;
+    MPI_Reduce(&local_word_total, &global_word_total, 1, MPI_LONG_LONG, MPI_SUM, 0, MPI_COMM_WORLD);
+    MPI_Reduce(&local_song_total, &global_song_total, 1, MPI_LONG_LONG, MPI_SUM, 0, MPI_COMM_WORLD);
+
+    if (rank == 0) {
+        ensure_output_dir(output_dir);
+    }
+
+    if (rank == 0) {
+        HashTable global_words;
+        HashTable global_artists;
+        ht_init(&global_words, word_counts.capacity);
+        ht_init(&global_artists, artist_counts.capacity);
+        ht_merge(&global_words, &word_counts);
+        ht_merge(&global_artists, &artist_counts);
+
+        ht_free(&word_counts);
+        ht_free(&artist_counts);
+
+        for (int source = 1; source < world_size; ++source) {
+            receive_hash_table(&global_words, source, 100, MPI_COMM_WORLD);
+            receive_hash_table(&global_artists, source, 200, MPI_COMM_WORLD);
+        }
+
+        snprintf(word_output_path, sizeof(word_output_path), "%s/word_counts.csv", output_dir);
+        snprintf(artist_output_path, sizeof(artist_output_path), "%s/top_artists.csv", output_dir);
+        snprintf(metrics_output_path, sizeof(metrics_output_path), "%s/performance_metrics.json", output_dir);
+
+        write_table_csv(&global_words, word_output_path, "word", word_limit);
+        write_table_csv(&global_artists, artist_output_path, "artist", artist_limit);
+
+        size_t word_array_size = 0;
+        Entry *word_entries = ht_to_array(&global_words, &word_array_size);
+        qsort(word_entries, word_array_size, sizeof(Entry), entry_compare_desc);
+        size_t artist_array_size = 0;
+        Entry *artist_entries = ht_to_array(&global_artists, &artist_array_size);
+        qsort(artist_entries, artist_array_size, sizeof(Entry), entry_compare_desc);
+
+        printf("=== Parallel Spotify Analysis ===\n");
+        printf("Total songs processed: %lld\n", (long long)global_song_total);
+        printf("Total words counted: %lld\n", (long long)global_word_total);
+        size_t preview_words = word_array_size < 10 ? word_array_size : 10;
+        printf("Top %zu words:\n", preview_words);
+        for (size_t i = 0; i < preview_words; ++i) {
+            printf("  %s: %lld\n", word_entries[i].key, word_entries[i].value);
+        }
+        size_t preview_artists = artist_array_size < 10 ? artist_array_size : 10;
+        printf("Top %zu artists:\n", preview_artists);
+        for (size_t i = 0; i < preview_artists; ++i) {
+            printf("  %s: %lld songs\n", artist_entries[i].key, artist_entries[i].value);
+        }
+
+        free(word_entries);
+        free(artist_entries);
+
+        ht_free(&global_words);
+        ht_free(&global_artists);
+    } else {
+        send_hash_table(&word_counts, 0, 100, MPI_COMM_WORLD);
+        send_hash_table(&artist_counts, 0, 200, MPI_COMM_WORLD);
+        ht_free(&word_counts);
+        ht_free(&artist_counts);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    double total_time = MPI_Wtime() - start_time;
+
+    double sum_compute = 0.0;
+    double max_compute = 0.0;
+    double min_compute = 0.0;
+    double sum_total = 0.0;
+    double max_total = 0.0;
+    double min_total = 0.0;
+
+    MPI_Reduce(&compute_time, &sum_compute, 1, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
+    MPI_Reduce(&compute_time, &max_compute, 1, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
+    MPI_Reduce(&compute_time, &min_compute, 1, MPI_DOUBLE, MPI_MIN, 0, MPI_COMM_WORLD);
+    MPI_Reduce(&total_time, &sum_total, 1, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
+    MPI_Reduce(&total_time, &max_total, 1, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
+    MPI_Reduce(&total_time, &min_total, 1, MPI_DOUBLE, MPI_MIN, 0, MPI_COMM_WORLD);
+
+    if (rank == 0) {
+        double avg_compute = sum_compute / world_size;
+        double avg_total = sum_total / world_size;
+        const char *metrics_path = metrics_output_path[0] ? metrics_output_path : "output/performance_metrics.json";
+        FILE *metrics_fp = fopen(metrics_path, "w");
+        if (metrics_fp) {
+            fprintf(metrics_fp, "{\n");
+            fprintf(metrics_fp, "  \"processes\": %d,\n", world_size);
+            fprintf(metrics_fp, "  \"total_songs\": %lld,\n", (long long)global_song_total);
+            fprintf(metrics_fp, "  \"total_words\": %lld,\n", (long long)global_word_total);
+            fprintf(metrics_fp, "  \"compute_time\": {\n");
+            fprintf(metrics_fp, "    \"avg_seconds\": %.6f,\n", avg_compute);
+            fprintf(metrics_fp, "    \"min_seconds\": %.6f,\n", min_compute);
+            fprintf(metrics_fp, "    \"max_seconds\": %.6f\n", max_compute);
+            fprintf(metrics_fp, "  },\n");
+            fprintf(metrics_fp, "  \"total_time\": {\n");
+            fprintf(metrics_fp, "    \"avg_seconds\": %.6f,\n", avg_total);
+            fprintf(metrics_fp, "    \"min_seconds\": %.6f,\n", min_total);
+            fprintf(metrics_fp, "    \"max_seconds\": %.6f\n", max_total);
+            fprintf(metrics_fp, "  }\n");
+            fprintf(metrics_fp, "}\n");
+            fclose(metrics_fp);
+        } else {
+            fprintf(stderr, "Failed to write performance metrics file\n");
+        }
+    }
+
+    MPI_Finalize();
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary
- add threaded processing to the standalone per-song word count utility and expose a --workers option
- document the new threaded execution mode and usage in the README

## Testing
- python -m compileall scripts/word_count_per_song.py

------
https://chatgpt.com/codex/tasks/task_e_68dc1dd3e6908329a0cab43100b260ef